### PR TITLE
fixes #8352 - fix possible duplicate definition of wget packages

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,10 @@
 # Candlepin installation packages
 class candlepin::install {
 
-  package { ['candlepin', "candlepin-${candlepin::tomcat}", 'wget']:
+  package { ['candlepin', "candlepin-${candlepin::tomcat}"]:
     ensure => $candlepin::version
   }
+
+  ensure_packages(['wget'])
 
 }


### PR DESCRIPTION
`ensure_packages` from puppet-stdlib should be used when installing non-core packages so there's no duplicate definitions.  foreman-proxy TFTP also requires wget, which causes such a duplicate definition when it's enabled:

```
[ERROR 2014-11-11 22:30:09 main] Duplicate declaration: Package[wget] is already declared in file /usr/share/katello-installer/modules/candlepin/manifests/install.pp:6; cannot redeclare at /usr/share/katello-installer/modules/foreman_proxy/manifests/tftp.pp:19 on node prometheus.bitbin.de
```
