### PR TITLE
Allow qpid 4.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "katello/qpid",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Needed for https://github.com/theforeman/puppet-qpid/pull/85. I don't think the breaking changes affect this module so we can continue to allow older versions.