### PR TITLE
Fixes #22567 - add sslEnabledProtocols parameter to server.xml.erb

### DIFF
--- a/spec/classes/candlepin_config_spec.rb
+++ b/spec/classes/candlepin_config_spec.rb
@@ -130,6 +130,7 @@ describe 'candlepin::config' do
         it "should setup the tomcat config file" do
           should contain_file("/etc/tomcat/server.xml").
             with_content(/sslProtocols="TLSv1.2,TLSv1.3"/).
+            with_content(/sslEnabledProtocols="TLSv1.2,TLSv1.3"/).
             with({})
         end
       end

--- a/templates/tomcat/server.xml.erb
+++ b/templates/tomcat/server.xml.erb
@@ -88,6 +88,7 @@
                maxThreads="150" scheme="https" secure="true"
                clientAuth="want"
                sslProtocols="<%= scope['::candlepin::tls_versions'].map { |version| "TLSv#{version}"}.join(",") %>"
+               sslEnabledProtocols="<%= scope['::candlepin::tls_versions'].map { |version| "TLSv#{version}"}.join(",") %>"
                keystoreFile="<%= scope['::candlepin::keystore_file'] %>"
                truststoreFile="<%= scope['::candlepin::truststore_file'] %>"
                keystorePass="<%= scope['::candlepin::keystore_password'] %>"


### PR DESCRIPTION
Based on the Tomcat docs (https://tomcat.apache.org/tomcat-7.0-doc/config/http.html), the `sslEnabledProtocols` parameter needs to be set in order to actually limit the SSL protocol versions being offered to the client. The `sslProtocols` value seems to only control the maximum version offered. 