### PR TITLE
Add debug logging placeholder to candlepin.conf

### DIFF
--- a/templates/candlepin.conf.erb
+++ b/templates/candlepin.conf.erb
@@ -33,3 +33,6 @@ candlepin.crl.file=<%= scope['candlepin::crl_file'] %>
 <% unless [nil, :undefined, :undef].include?(scope['candlepin::ca_key_password']) -%>
 candlepin.ca_key_password=<%= scope['candlepin::ca_key_password'] %>
 <%- end -%>
+
+# uncomment to enable debug logging in candlepin.log:
+#log4j.logger.org.candlepin=DEBUG


### PR DESCRIPTION
We use the same placeholder internally. Might save someone
troubleshooting a bit of brainpower at some point :-).