### PR TITLE
Fixes #25062: set hibernate logging to ERROR

### DIFF
--- a/templates/candlepin.conf.erb
+++ b/templates/candlepin.conf.erb
@@ -34,5 +34,8 @@ candlepin.crl.file=<%= scope['candlepin::crl_file'] %>
 candlepin.ca_key_password=<%= scope['candlepin::ca_key_password'] %>
 <%- end -%>
 
+# Required for https://hibernate.atlassian.net/browse/HHH-12927
+log4j.logger.org.hibernate.internal.SessionImpl=ERROR
+
 # uncomment to enable debug logging in candlepin.log:
 #log4j.logger.org.candlepin=DEBUG


### PR DESCRIPTION
See https://hibernate.atlassian.net/browse/HHH-12927. This is required for Candlepin 2.5.7-1.