### PR TITLE
Drop unused ports and switch run_init to false

### DIFF
--- a/examples/basic_candlepin.pp
+++ b/examples/basic_candlepin.pp
@@ -2,27 +2,34 @@
 # Create certificates then install candlepin
 #
 
-Exec {
-  path    => ['/usr/bin'],
-  cwd     => '/etc/candlepin/certs/',
-}
+$keydir = '/etc/candlepin/certs'
+$keystore = "${keydir}/keystore"
+$keystore_password = 'secret'
+$ca_key = "${keydir}/candlepin-ca.key"
+$ca_cert = "${keydir}/candlepin-ca.crt"
 
-file { '/etc/candlepin/':
-  ensure => directory,
-}
-file { '/etc/candlepin/certs/':
-  ensure => directory,
+exec { "/bin/mkdir -p ${keydir}":
+  creates => $keydir,
 } ->
 exec { 'Create CA key':
-  command => 'openssl genrsa -out candlepin-ca.key 2048',
-  creates => '/etc/candlepin/certs/candlepin-ca.key',
+  command => "/usr/bin/openssl genrsa -out '${ca_key}' 2048",
+  creates => $ca_key,
   notify  => Service['tomcat'],
 } ->
-exec { 'Create CA certficates':
-  command => 'openssl req -new -x509 -key candlepin-ca.key -out candlepin-ca.crt -nodes -x509 -subj "/C=US/ST=North Carolina/L=Raleigh/O=CustomKatelloCA/CN=www.candlepin.example.com"',
-  creates => '/etc/candlepin/certs/candlepin-ca.crt',
+exec { 'Create CA certficate':
+  command => "/usr/bin/openssl req -new -x509 -key '${ca_key}' -out '${ca_cert}' -nodes -x509 -subj '/C=US/ST=North Carolina/L=Raleigh/O=CustomKatelloCA/CN=${facts['fqdn']}'",
+  creates => $ca_cert,
+  notify  => Service['tomcat'],
+} ->
+exec { 'Create keystore':
+  command => "/usr/bin/openssl pkcs12 -export -in '${ca_cert}' -inkey '${ca_key}' -out '${keystore}' -name tomcat -CAfile '${ca_cert}' -caname root -password 'pass:${keystore_password}'",
+  creates => $keystore,
   notify  => Service['tomcat'],
 } ->
 class { 'candlepin':
-  manage_repo => true,
+  manage_repo       => true,
+  ca_key            => $ca_key,
+  ca_cert           => $ca_cert,
+  keystore_file     => $keystore,
+  keystore_password => $keystore_password,
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,5 +8,7 @@ class candlepin::install {
     ensure => $candlepin::version,
   }
 
-  ensure_packages(['wget'], { ensure => $candlepin::wget_version, })
+  if $candlepin::run_init {
+    ensure_packages(['wget'], { ensure => $candlepin::wget_version, })
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -68,7 +68,7 @@ class candlepin::params {
 
   $version = 'present'
   $wget_version = 'present'
-  $run_init = true
+  $run_init = false
   $adapter_module = undef
   $enable_hbm2ddl_validate = true
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,7 +14,7 @@ class candlepin::service {
   if $candlepin::run_init {
     exec { 'cpinit':
       # tomcat startup is slow - try multiple times (the initialization service is idempotent)
-      command => '/usr/bin/wget --no-proxy --timeout=30 --tries=40 --wait=20 --retry-connrefused -qO- http://localhost:8080/candlepin/admin/init > /var/log/candlepin/cpinit.log 2>&1 && touch /var/lib/candlepin/cpinit_done',
+      command => "/usr/bin/wget --no-check-certificate --no-proxy --timeout=30 --tries=40 --wait=20 --retry-connrefused -qO- https://localhost:${candlepin::ssl_port}/candlepin/admin/init > /var/log/candlepin/cpinit.log 2>&1 && touch /var/lib/candlepin/cpinit_done",
       require => [Package['wget'], Service['tomcat']],
       creates => '/var/lib/candlepin/cpinit_done',
       # timeout is roughly "wait" * "tries" from above

--- a/spec/acceptance/basic_candlepin_spec.rb
+++ b/spec/acceptance/basic_candlepin_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper_acceptance'
 describe 'candlepin works' do
   include_examples 'the example', 'basic_candlepin.pp'
 
-  describe port(8080) do
+  describe port(8443) do
     it { is_expected.to be_listening }
   end
 
-  describe command('curl -s -o /dev/null -w \'%{http_code}\' http://localhost:8080/candlepin/status') do 
+  describe command('curl -k -s -o /dev/null -w \'%{http_code}\' https://localhost:8443/candlepin/status') do
       its(:stdout) { should eq "200" }
   end
 end

--- a/templates/tomcat/server.xml.erb
+++ b/templates/tomcat/server.xml.erb
@@ -69,16 +69,6 @@
          APR (HTTP/AJP) Connector: /docs/apr.html
          Define a non-SSL HTTP/1.1 Connector on port 8080
     -->
-    <Connector port="8080" protocol="HTTP/1.1"
-               connectionTimeout="20000"
-               redirectPort="<%= scope['::candlepin::ssl_port'] %>" />
-    <!-- A "Connector" using the shared thread pool-->
-    <!--
-    <Connector executor="tomcatThreadPool"
-               port="8080" protocol="HTTP/1.1"
-               connectionTimeout="20000"
-               redirectPort="<%= scope['::candlepin::ssl_port'] %>" />
-    -->
     <!-- Define a SSL HTTP/1.1 Connector on port <%= scope['::candlepin::ssl_port'] %>
          This connector uses the JSSE configuration, when using APR, the
          connector should be using the OpenSSL style configuration
@@ -95,10 +85,6 @@
                keystoreType="<%= scope['::candlepin::keystore_type'] %>"
                ciphers="<%= scope['::candlepin::ciphers'].join(",\n                    ") %>"
                truststorePass="<%= scope['candlepin::truststore_password'] %>" />
-
-    <!-- Define an AJP 1.3 Connector on port 8009 -->
-    <Connector port="8009" protocol="AJP/1.3" redirectPort="<%= scope['::candlepin::ssl_port'] %>" />
-
 
     <!-- An Engine represents the entry point (within Catalina) that processes
          every request.  The Engine implementation for Tomcat stand alone


### PR DESCRIPTION
From my testing and talking to Candlepin team:

 * Calling init is really a development task and not needed for production
 * AJP connector seems to be only useful if using Apache and even then not if you are using mod_proxy
 * The init can be called via HTTPS so 8080 is not needed at all

This reduces Candlepin setup time, and reduces the number of ports that Candlepin takes up.