### PR TITLE
Use Candlepin default cert locations

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,6 +20,16 @@ class candlepin::config {
     group => 'tomcat',
   }
 
+  file { '/etc/candlepin/certs/candlepin-ca.crt':
+    ensure => file,
+    source => $candlepin::ca_cert,
+  }
+
+  file { '/etc/candlepin/certs/candlepin-ca.key':
+    ensure => file,
+    source => $candlepin::ca_key,
+  }
+
   file { '/etc/tomcat/server.xml':
     ensure  => file,
     content => template('candlepin/tomcat/server.xml.erb'),

--- a/templates/candlepin.conf.erb
+++ b/templates/candlepin.conf.erb
@@ -27,8 +27,8 @@ candlepin.auth.oauth.consumer.<%= scope['candlepin::oauth_key'] %>.secret=<%= sc
 module.config.adapter_module=<%= scope['candlepin::adapter_module'] %>
 <%- end -%>
 
-candlepin.ca_key=<%= scope['candlepin::ca_key'] %>
-candlepin.ca_cert=<%= scope['candlepin::ca_cert'] %>
+candlepin.ca_key=/etc/candlepin/certs/candlepin-ca.key
+candlepin.ca_cert=/etc/candlepin/certs/candlepin-ca.crt
 candlepin.crl.file=<%= scope['candlepin::crl_file'] %>
 <% unless [nil, :undefined, :undef].include?(scope['candlepin::ca_key_password']) -%>
 candlepin.ca_key_password=<%= scope['candlepin::ca_key_password'] %>


### PR DESCRIPTION
This changes to allowing custom configuration of the certificates themselves but not their location on the file system. This provides more consistent behavior between Candlepin installs and isolates Candlepin's needed configuration from the rest of the system.