### PR TITLE
Candlepin service running via a systemd container

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,7 @@ fixtures:
     concat:     'https://github.com/puppetlabs/puppetlabs-concat'
     postgresql: 'https://github.com/puppetlabs/puppetlabs-postgresql.git'
     qpid:       'https://github.com/theforeman/puppet-qpid.git'
+    systemd:    'https://github.com/camptocamp/puppet-systemd.git'
     yumrepo_core:
       repo: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'
       puppet_version: '>= 6.0.0'

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -66,7 +66,7 @@ class candlepin::database::postgresql(
                        >> ${log_dir}/cpdb.log \
                        2>&1 && touch /var/lib/candlepin/cpdb_done",
       creates => '/var/lib/candlepin/cpdb_done',
-      before  => Service['tomcat'],
+      before  => Service[$candlepin::service_name],
       require => Concat['/etc/candlepin/candlepin.conf'],
     }
     # if both manage_db and init_db enforce order of resources

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -176,6 +176,15 @@
 # @param shutdown_wait
 #   Time to wait in seconds, before killing process
 #
+# @param container
+#   Run Candlepin as a systemd service via a container
+#
+# @param container_version
+#   Version of Candlepin container to run when running as a container
+#
+# @param container_image
+#   Candlepin container image to use (default: quay.io/foreman/candlepin)
+#
 class candlepin (
   Boolean $manage_db = $candlepin::params::manage_db,
   Boolean $init_db = $candlepin::params::init_db,
@@ -234,10 +243,19 @@ class candlepin (
   Optional[String] $lang = $candlepin::params::lang,
   Boolean $security_manager = $candlepin::params::security_manager,
   Optional[Integer[0]] $shutdown_wait = $candlepin::params::shutdown_wait,
+  Boolean $container = $candlepin::params::container,
+  String $container_version = $candlepin::params::container_version,
+  String $container_image = $candlepin::params::container_image,
 ) inherits candlepin::params {
   if $amq_enable {
     assert_type(String, $amqp_keystore_password)
     assert_type(String, $amqp_truststore_password)
+  }
+
+  if $candlepin::container {
+    $service_name = 'candlepin'
+  } else {
+    $service_name = 'tomcat'
   }
 
   $amqpurl = "tcp://${qpid_hostname}:${qpid_ssl_port}?ssl='true'&ssl_cert_alias='amqp-client'"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,17 +4,28 @@
 class candlepin::install {
   assert_private()
 
-  package { ['candlepin']:
-    ensure => $candlepin::version,
-  }
+  if $candlepin::container {
+    ensure_packages(['podman'])
 
-  if $facts['selinux'] {
-    package { ['candlepin-selinux']:
+    exec { 'pull candlepin image':
+      command => "/usr/bin/podman pull ${candlepin::container_image}:${candlepin::container_version}",
+      unless  => "/usr/bin/podman images ${candlepin::container_image}:${candlepin::container_version}",
+      require => Package['podman'],
+      timeout => 600,
+    }
+  } else {
+    package { ['candlepin']:
       ensure => $candlepin::version,
     }
-  }
 
-  if $candlepin::run_init {
-    ensure_packages(['wget'], { ensure => $candlepin::wget_version, })
+    if $facts['selinux'] {
+      package { ['candlepin-selinux']:
+        ensure => $candlepin::version,
+      }
+    }
+
+    if $candlepin::run_init {
+      ensure_packages(['wget'], { ensure => $candlepin::wget_version, })
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,10 @@
 class candlepin::params {
   $ssl_port = 8443
 
+  $container = false
+  $container_version = 'latest'
+  $container_image = 'quay.io/foreman/candlepin'
+
   $manage_db = true
   $init_db = true
   $db_type = 'postgresql'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,7 +4,21 @@
 class candlepin::service {
   assert_private()
 
-  service { 'tomcat':
+  if $candlepin::container {
+    file { '/etc/sysconfig/candlepin':
+      ensure  => file,
+      content => template('candlepin/candlepin.sysconfig.erb'),
+      notify  => Service[$candlepin::service_name],
+      mode    => '0640',
+    }
+
+    systemd::unit_file { 'candlepin.service':
+      content => template('candlepin/candlepin.service.erb'),
+      notify  => Service[$candlepin::service_name],
+    }
+  }
+
+  service { $candlepin::service_name:
     ensure     => running,
     enable     => true,
     hasstatus  => true,
@@ -15,7 +29,7 @@ class candlepin::service {
     exec { 'cpinit':
       # tomcat startup is slow - try multiple times (the initialization service is idempotent)
       command => "/usr/bin/wget --no-check-certificate --no-proxy --timeout=30 --tries=40 --wait=20 --retry-connrefused -qO- https://localhost:${candlepin::ssl_port}/candlepin/admin/init > /var/log/candlepin/cpinit.log 2>&1 && touch /var/lib/candlepin/cpinit_done",
-      require => [Package['wget'], Service['tomcat']],
+      require => [Package['wget'], Service[$candlepin::service_name]],
       creates => '/var/lib/candlepin/cpinit_done',
       # timeout is roughly "wait" * "tries" from above
       timeout =>  800,

--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,10 @@
     {
       "name": "katello/qpid",
       "version_requirement": ">= 3.0.0 < 5.0.0"
+    },
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 0.4.0 < 3.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -266,6 +266,25 @@ describe 'candlepin' do
         end
       end
 
+      context 'with container true' do
+        let :params do
+          {container: true}
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_service('candlepin') }
+        it { is_expected.to contain_package('podman').with_ensure('present') }
+        it { is_expected.to contain_systemd__unit_file('candlepin.service') }
+        it do
+          is_expected.to contain_file("/etc/sysconfig/candlepin").
+            with_content(/POSTGRES_SERVICE_HOST/).
+            with_content(/POSTGRES_PORT/).
+            with_content(/POSTGRES_DB/).
+            with_content(/POSTGRES_USER/).
+            with_content(/POSTGRES_PASSWORD/)
+        end
+      end
+
       describe 'notify' do
         let :pre_condition do
           <<-EOS

--- a/templates/candlepin.service.erb
+++ b/templates/candlepin.service.erb
@@ -1,0 +1,18 @@
+[Unit]
+Description=Candlepin
+Wants=syslog.service
+
+[Service]
+Restart=always
+RestartSec=30
+TimeoutStartSec=0
+TimeoutSec=300
+ExecStartPre=-/usr/bin/podman rm "candlepin-1"
+ExecStart=/usr/bin/podman run --name candlepin-1 --env-file /etc/sysconfig/candlepin --net host -v /etc/candlepin:/etc/candlepin:z -v /etc/tomcat:/etc/tomcat:z -p <%= scope['candlepin::ssl_port'] %> <%= scope['candlepin::container_image'] %>:<%= scope['candlepin::container_version'] %>
+ExecReload=-/usr/bin/podman stop "candlepin-1"
+ExecReload=-/usr/bin/podman rm "candlepin-1"
+ExecStop=-/usr/bin/podman stop "candlepin-1"
+EnvironmentFile=-/etc/sysconfig/candlepin
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/candlepin.sysconfig.erb
+++ b/templates/candlepin.sysconfig.erb
@@ -1,0 +1,5 @@
+POSTGRES_SERVICE_HOST=<%= scope['candlepin::db_host'] %>
+POSTGRES_PORT=<%= scope['candlepin::db_port'] %>
+POSTGRES_DB=<%= scope['candlepin::db_name'] %>
+POSTGRES_USER=<%= scope['candlepin::db_user'] %>
+POSTGRES_PASSWORD=<%= scope['candlepin::db_password'] %>


### PR DESCRIPTION
This requires a few other changes to go in to work that have open PRs. The idea is to introduce a candlepin service that runs a container via podman. This introduces a new paramter to switch to this mode. One downside is that this creates two service paths: tomcat service and Candlepin service. I debated first migrating to a Candlepin service that starts tomcat for non-container installs so there is one service with two implementations but wanted to see what others thought first.

Dependent PRs:
 * https://github.com/theforeman/puppet-certs/pull/225
 * https://github.com/theforeman/puppet-katello/pull/263
 * https://github.com/theforeman/puppet-candlepin/pull/120