### PR TITLE
Add candlepin-selinux during install

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,6 +8,12 @@ class candlepin::install {
     ensure => $candlepin::version,
   }
 
+  if $facts['selinux'] {
+    package { ['candlepin-selinux']:
+      ensure => $candlepin::version,
+    }
+  }
+
   if $candlepin::run_init {
     ensure_packages(['wget'], { ensure => $candlepin::wget_version, })
   }


### PR DESCRIPTION
This should fix the current issue in centos7-devel. I think it shouldn't affect production, as the katello rpm is installed, which [requires candlepin-selinux](https://github.com/theforeman/foreman-packaging/blob/rpm/develop/packages/katello/katello/katello.spec#L65).

To test:

```yaml
centos7-devel-test:
  box: centos7-devel
  ansible:
    playbook: playbooks/devel.yml
    group: devel
    # verbose: v
    variables:
      katello_devel_github_username: <changeme>
      foreman_installer_module_prs:
        - katello/candlepin/124
```