### PR TITLE
Fixes #25966 - order the tomcat service after all qpid binds

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,4 +22,7 @@ class candlepin::service {
     }
   }
 
+  if $candlepin::amq_enable {
+    Qpid::Config::Bind <| tag == 'qpid' |> -> Service <| tag == 'tomcat' |>
+  }
 }


### PR DESCRIPTION
this is required for Candlepin 2.5.10, see [1] for details

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1570534

I have no idea how to write a test for this :(