### PR TITLE
Bump version to 9.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "katello-candlepin",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "author": "katello",
   "summary": "Configure and install Candlepin entitlement server.",
   "license": "GPL-3.0+",


### PR DESCRIPTION
504ed85be6eabf3a9aa7d431093bda74adc4682e was a breaking change so the version should reflect this. This forces modules that depend on it to be ready for it.