### PR TITLE
Fixes #29625 - Stop accepting TLS 1.1 connections

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,7 +58,6 @@ class candlepin::params {
   ]
 
   $tls_versions = [
-    '1.1',
     '1.2',
   ]
 


### PR DESCRIPTION
Katello is the only thing connecting to Candlepin and current setups shouldn't use TLS 1.1 anymore. PCI compliant setups are also required to disable it. By doing this out of the box, the software becomes more secure and more compliant.