### PR TITLE
Use the namespaced pg password function

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -37,7 +37,7 @@ class candlepin::database::postgresql(
     include postgresql::client, postgresql::server
     postgresql::server::db { $db_name:
       user     => $db_user,
-      password => postgresql_password($db_user, $db_password),
+      password => postgresql::postgresql_password($db_user, $db_password),
       encoding => 'utf8',
       locale   => 'en_US.utf8',
     }

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 4.2.0 < 7.0.0"
+      "version_requirement": ">= 6.5.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Since puppetlabs/postgresql 6.5.0 the non-namespaced function raises a deprecation warning. This uses the modern version.