### PR TITLE
Fixes #30523: Create providers to make database migration idempotent

### DIFF
--- a/lib/puppet/provider/cpdb_create/cpdb_create.rb
+++ b/lib/puppet/provider/cpdb_create/cpdb_create.rb
@@ -1,0 +1,38 @@
+Puppet::Type.type(:cpdb_create).provide(:cpdb_create) do
+
+  commands :cpdb => '/usr/share/candlepin/cpdb'
+
+  def create
+    create_database
+    write_done_file
+  end
+
+  def exists?
+    File.exist?(done_file)
+  end
+
+  private
+
+  def create_database
+    cpdb(
+      "--create",
+      "--schema-only",
+      "--dbhost=#{resource[:db_host]}",
+      "--dbport=#{resource[:db_port]}",
+      "--database=#{resource[:db_name]}#{resource[:ssl_options]}",
+      "--user=#{resource[:db_user]}",
+      "--password=#{resource[:db_password]}"
+    )
+  end
+
+  def done_file
+    "/var/lib/candlepin/.puppet-candlepin-cpdb-create-done"
+  end
+
+  def write_done_file
+    File.open(done_file, 'w') do |file|
+      file.write(Time.now)
+    end
+  end
+
+end

--- a/lib/puppet/provider/cpdb_update/cpdb_update.rb
+++ b/lib/puppet/provider/cpdb_update/cpdb_update.rb
@@ -1,0 +1,49 @@
+Puppet::Type.type(:cpdb_update).provide(:cpdb_update) do
+
+  commands :cpdb => '/usr/share/candlepin/cpdb'
+  commands :rpm => 'rpm'
+
+  def create
+    migrate_database
+    update_version_file
+  end
+
+  def exists?
+    return false if previous_candlepin_version.nil?
+    return false if candlepin_rpm_version.nil?
+
+    Gem::Version.new(previous_candlepin_version) == Gem::Version.new(candlepin_rpm_version)
+  end
+
+  private
+
+  def migrate_database
+    output = cpdb(
+      "--update",
+      "--dbhost=#{resource[:db_host]}",
+      "--dbport=#{resource[:db_port]}",
+      "--database=#{resource[:db_name]}#{resource[:ssl_options]}",
+      "--user=#{resource[:db_user]}",
+      "--password=#{resource[:db_password]}"
+    )
+  end
+
+  def version_file
+    "/var/lib/candlepin/.puppet-candlepin-rpm-version"
+  end
+
+  def update_version_file
+    File.open(version_file, "w") do |file|
+      file.write(candlepin_rpm_version)
+    end
+  end
+
+  def candlepin_rpm_version
+    rpm('-q', 'candlepin', '--queryformat=%{version}')
+  end
+
+  def previous_candlepin_version
+    File.read(version_file) if File.exist?(version_file)
+  end
+
+end

--- a/lib/puppet/type/cpdb_create.rb
+++ b/lib/puppet/type/cpdb_create.rb
@@ -1,0 +1,31 @@
+Puppet::Type.newtype(:cpdb_create) do
+  desc 'Runs cpdb create command to setup database schema'
+
+  ensurable
+
+  newparam(:db_name, :namevar => true)
+
+  newparam(:db_host) do
+    desc "Database host"
+  end
+
+  newparam(:db_port) do
+    desc "Database port"
+  end
+
+  newparam(:ssl_options) do
+    desc "SSL options if necessary for connecting to the database"
+  end
+
+  newparam(:db_user) do
+    desc "User to connect to the database with"
+  end
+
+  newparam(:db_password) do
+    desc "Password of the database user"
+  end
+
+  autorequire(:concat) do
+    ['/etc/candlepin/candlepin.conf']
+  end
+end

--- a/lib/puppet/type/cpdb_update.rb
+++ b/lib/puppet/type/cpdb_update.rb
@@ -1,0 +1,35 @@
+Puppet::Type.newtype(:cpdb_update) do
+  desc 'Runs cpdb update command to migrate the database'
+
+  ensurable
+
+  newparam(:db_name, :namevar => true)
+
+  newparam(:db_host) do
+    desc "Database host"
+  end
+
+  newparam(:db_port) do
+    desc "Database port"
+  end
+
+  newparam(:ssl_options) do
+    desc "SSL options if necessary for connecting to the database"
+  end
+
+  newparam(:db_user) do
+    desc "User to connect to the database with"
+  end
+
+  newparam(:db_password) do
+    desc "Password of the database user"
+  end
+
+  autorequire(:concat) do
+    ['/etc/candlepin/candlepin.conf']
+  end
+
+  autorequire(:cpdb_create) do
+    [self[:db_name]]
+  end
+end

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -54,37 +54,26 @@ class candlepin::database::postgresql(
       default => ''
     }
 
-    exec { 'cpdb create':
-      path    => '/usr/share/candlepin:/bin',
-      command => "cpdb --create \
-                       --schema-only \
-                       --dbhost=${db_host} \
-                       --dbport=${db_port} \
-                       --database='${db_name}${ssl_options}' \
-                       --user='${db_user}'  \
-                       --password='${db_password}' \
-                       >> ${log_dir}/cpdb.log \
-                       2>&1 && touch /var/lib/candlepin/cpdb_done",
-      creates => '/var/lib/candlepin/cpdb_done',
-      require => Concat['/etc/candlepin/candlepin.conf'],
+    cpdb_create { $db_name:
+      ensure      => present,
+      db_host     => $db_host,
+      db_port     => $db_port,
+      db_user     => $db_user,
+      db_password => $db_password,
+      ssl_options => $ssl_options,
     } ->
-
-    exec { 'cpdb update':
-      path    => '/usr/share/candlepin:/bin',
-      command => "cpdb --update \
-                       --dbhost=${db_host} \
-                       --dbport=${db_port} \
-                       --database='${db_name}${ssl_options}' \
-                       --user='${db_user}'  \
-                       --password='${db_password}' \
-                       >> ${log_dir}/cpdb.log \
-                       2>&1 && touch /var/lib/candlepin/cpdb_update_done",
-      creates => '/var/lib/candlepin/cpdb_update_done',
+    cpdb_update { $db_name:
+      ensure      => present,
+      db_host     => $db_host,
+      db_port     => $db_port,
+      db_user     => $db_user,
+      db_password => $db_password,
+      ssl_options => $ssl_options,
     }
 
     # if both manage_db and init_db enforce order of resources
     if $manage_db {
-      Postgresql::Server::Db[$db_name] -> Exec['cpdb create']
+      Postgresql::Server::Db[$db_name] -> Cpdb_create[$db_name]
     }
   }
 }

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -65,13 +65,12 @@ describe 'candlepin' do
         it { is_expected.not_to contain_class('candlepin::database::mysql') }
         it { is_expected.to contain_class('candlepin::database::postgresql') }
         it 'migrates the database' do
-          is_expected.to contain_exec('cpdb create')
+          is_expected.to contain_cpdb_create('candlepin')
             .that_subscribes_to(['Package[candlepin]', 'Concat[/etc/candlepin/candlepin.conf]'])
             .that_requires('Postgresql::Server::Db[candlepin]')
             .that_notifies('Service[tomcat]')
-          is_expected.to contain_exec('cpdb update')
+          is_expected.to contain_cpdb_update('candlepin')
             .that_subscribes_to(['Package[candlepin]', 'Concat[/etc/candlepin/candlepin.conf]'])
-            .that_requires('Exec[cpdb create]')
             .that_notifies('Service[tomcat]')
         end
         it { is_expected.to contain_postgresql__server__db('candlepin') }


### PR DESCRIPTION
@ekohl Here is a provider based implementation of the idempotent migration idea so that the module itself handles it. This should also make it easy to transition when Candlepin handles this officially.