### PR TITLE
Refs #29220 - Add missing parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,6 +200,7 @@ class candlepin (
   Boolean $security_manager = $candlepin::params::security_manager,
   Optional[Integer[0]] $shutdown_wait = $candlepin::params::shutdown_wait,
   String $expired_pools_schedule = $candlepin::params::expired_pools_schedule,
+  String $certificate_revocation_list_task_schedule = $candlepin::params::certificate_revocation_list_task_schedule,
   Stdlib::Host $artemis_host = $candlepin::params::host,
   Stdlib::Port $artemis_port = $candlepin::params::artemis_port,
   String $artemis_client_dn = $candlepin::params::artemis_client_dn,


### PR DESCRIPTION
504ed85be6eabf3a9aa7d431093bda74adc4682e introduced this variable, but lacked the actual parameter. While it was inherited so the default at least worked, the latest puppet-lint-param-docs requires all parameters that are documented to actually exist. There is a `@param` statement for it and after this PR the actual parameter also exists.