### PR TITLE
Drop dependency on puppet-selinux

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,6 @@ fixtures:
     concat:     'https://github.com/puppetlabs/puppetlabs-concat'
     postgresql: 'https://github.com/puppetlabs/puppetlabs-postgresql.git'
     qpid:       'https://github.com/theforeman/puppet-qpid.git'
-    selinux:          'https://github.com/voxpupuli/puppet-selinux'
     selinux_core:
       repo:           'https://github.com/puppetlabs/puppetlabs-selinux_core'
       puppet_version: '>= 6.0.0'

--- a/manifests/artemis.pp
+++ b/manifests/artemis.pp
@@ -45,6 +45,9 @@ class candlepin::artemis {
   }
 
   if $facts['os']['selinux']['enabled'] {
-    selinux::boolean { 'candlepin_can_bind_activemq_port': }
+    selboolean { 'candlepin_can_bind_activemq_port':
+      value      => 'on',
+      persistent => true,
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -23,10 +23,6 @@
     {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 1.0.0 < 7.0.0"
-    },
-    {
-      "name": "puppet/selinux",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
selinux depends on on selinux_core which provides the selboolean type. selinux::boolean is a thin wrapper around this but it doesn't provide anything more than this.