### PR TITLE
Enable pki-core module on EL8

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,9 +4,20 @@
 class candlepin::install {
   assert_private()
 
+  $enable_pki_core = $facts['os']['release']['major'] == '8'
+
   if $candlepin::java_package {
     ensure_packages([$candlepin::java_package])
     Package[$candlepin::java_package] -> Package['candlepin']
+  }
+
+  if $enable_pki_core {
+    package { 'pki-core':
+      ensure      => installed,
+      enable_only => true,
+      provider    => 'dnfmodule',
+      before      => Package['candlepin'],
+    }
   }
 
   package { ['candlepin']:
@@ -16,6 +27,10 @@ class candlepin::install {
   if $facts['os']['selinux']['enabled'] {
     package { ['candlepin-selinux']:
       ensure => $candlepin::version,
+    }
+
+    if $enable_pki_core {
+      Package['pki-core'] -> Package['candlepin-selinux']
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 5.5.20 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,10 +1,6 @@
 $major = $facts['os']['release']['major']
 
 if $major == '8' {
-  # https://tickets.puppetlabs.com/browse/PUP-9978
-  exec { '/usr/bin/dnf -y module enable pki-core':
-  }
-
   package { 'glibc-langpack-en':
     ensure => installed,
   }


### PR DESCRIPTION
On EL8 Candlepin needs the pki-module to be enabled. This needs Puppet 5.5.20 or Puppet 6.15.0 which introduced the dnfmodule provider.