### PR TITLE
Drop unknown Tomcat properties

### DIFF
--- a/templates/tomcat/server.xml.erb
+++ b/templates/tomcat/server.xml.erb
@@ -123,8 +123,7 @@
            Note: XML Schema validation will not work with Xerces 2.2.
        -->
       <Host name="localhost"  appBase="webapps"
-            unpackWARs="true" autoDeploy="true"
-            xmlValidation="false" xmlNamespaceAware="false">
+            unpackWARs="true" autoDeploy="true">
 
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->


### PR DESCRIPTION
Setting property 'xmlValidation' to 'false' did not find a matching property.
Setting property 'xmlNamespaceAware' to 'false' did not find a matching property.