### PR TITLE
Pre-create some tomcat config files in selinux enabled acceptance tests

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -25,6 +25,18 @@ if $facts['os']['selinux']['enabled'] {
     ensure  => installed,
     require => Yumrepo['candlepin'],
   }
+
+  # Workaround for https://github.com/theforeman/puppet-candlepin/issues/185#issuecomment-822284497
+  $tomcat_conf_files = [
+    '/usr/share/tomcat/conf/login.config',
+    '/usr/share/tomcat/conf/cert-users.properties',
+    '/usr/share/tomcat/conf/cert-roles.properties',
+    '/usr/share/tomcat/conf/conf.d/jaas.conf'
+  ]
+  file { $tomcat_conf_files:
+    ensure   => file,
+    require  => Package['candlepin-selinux'],
+  }
 }
 
 # Used to test which TLS versions are enabled


### PR DESCRIPTION
When the tomcat RPM is installed, matchpathcon returns
different file context before vs. after touching the files
/usr/share/tomcat/conf/{login.config,conf.d/jaas.conf} and
/usr/share/tomcat/conf/cert-{users,roles}.properties
which breaks idempotence in selinux enabled environments.
This bug should likely be fixed in the RPM packaging of tomcat, but
in the meantime we can work around it by pre-creating the files to
ensure correct file context is returned when puppet is first run.