### PR TITLE
POC: Manage truststore completely within module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,7 @@ fixtures:
   repositories:
     stdlib:     'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     extlib:     'https://github.com/voxpupuli/puppet-extlib'
+    certs:      'https://github.com/theforeman/puppet-certs'
     concat:     'https://github.com/puppetlabs/puppetlabs-concat'
     postgresql: 'https://github.com/puppetlabs/puppetlabs-postgresql.git'
     selinux_core:

--- a/examples/basic_candlepin.pp
+++ b/examples/basic_candlepin.pp
@@ -2,13 +2,17 @@
 # Create certificates then install candlepin
 #
 
-$keydir = '/etc/candlepin/certs'
-$keystore = "${keydir}/keystore"
+$keydir = '/etc/pki'
 $keystore_password = 'secret'
-$truststore = "${keydir}/truststore"
 $truststore_password = 'secret'
 $ca_key = "${keydir}/candlepin-ca.key"
 $ca_cert = "${keydir}/candlepin-ca.crt"
+
+$common_name = $facts['networking']['fqdn']
+$dir = '/etc/pki'
+$tomcat_key = "${dir}/${common_name}.key"
+$tomcat_req = "${dir}/${common_name}.req"
+$tomcat_cert = "${dir}/${common_name}.crt"
 
 exec { "/bin/mkdir -p ${keydir}":
   creates => $keydir,
@@ -23,40 +27,28 @@ exec { 'Create CA certficate':
   creates => $ca_cert,
   notify  => Service['tomcat'],
 } ->
-exec { 'Create keystore':
-  command => "/usr/bin/openssl pkcs12 -export -in '${ca_cert}' -inkey '${ca_key}' -out '${keystore}' -name tomcat -CAfile '${ca_cert}' -caname root -password 'pass:${keystore_password}'",
-  creates => $keystore,
-  notify  => Service['tomcat'],
+exec { "Create ${common_name} tomcat key":
+  command => "/usr/bin/openssl genrsa -out '${tomcat_key}' 2048",
+  creates => $tomcat_key,
+} ->
+exec { "Create ${common_name} tomcat certificate signing request":
+  command => "/usr/bin/openssl req -new -key '${tomcat_key}' -out '${tomcat_req}' -subj '/C=US/ST=North Carolina/CN=${common_name}'",
+  creates => $tomcat_req,
+} ->
+exec { "Create ${common_name} tomcat certificate":
+  command => "/usr/bin/openssl x509 -req -in '${tomcat_req}' -out '${tomcat_cert}' -CA '${ca_cert}' -CAkey '${ca_key}' -set_serial 1",
+  creates => $tomcat_cert,
 } ->
 package { ['java']: } ->
-exec { 'Create truststore':
-  command => "/usr/bin/keytool -import -v -keystore ${truststore} -alias candlepin-ca -file ${ca_cert} -noprompt -storepass ${truststore_password} -storetype pkcs12",
-  creates => $truststore,
-} ->
-file { $ca_key:
-  mode  => '0440',
-  group => 'tomcat',
-} ->
-file { $ca_cert:
-  mode  => '0440',
-  group => 'tomcat',
-} ->
-file { $keystore:
-  mode  => '0440',
-  group => 'tomcat',
-} ->
-file { $truststore:
-  mode  => '0440',
-  group => 'tomcat',
-} ->
 class { 'candlepin':
-  ca_key              => $ca_key,
-  ca_cert             => $ca_cert,
-  keystore_file       => $keystore,
-  keystore_password   => $keystore_password,
-  truststore_file     => $truststore,
-  truststore_password => $truststore_password,
-  java_package        => 'java-11-openjdk',
-  java_home           => '/usr/lib/jvm/jre-11',
-  artemis_client_dn   => Deferred('pick', ['', 'CN=ActiveMQ Artemis Deferred, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ']),
+  ca_key                     => $ca_key,
+  ca_cert                    => $ca_cert,
+  keystore_password          => $keystore_password,
+  truststore_password        => $truststore_password,
+  tomcat_ssl_cert            => $tomcat_cert,
+  tomcat_ssl_key             => $tomcat_key,
+  artemis_client_certificate => $tomcat_cert,
+  java_package               => 'java-11-openjdk',
+  java_home                  => '/usr/lib/jvm/jre-11',
+  artemis_client_dn          => Deferred('pick', ['', 'CN=ActiveMQ Artemis Deferred, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ']),
 }

--- a/manifests/certificates.pp
+++ b/manifests/certificates.pp
@@ -1,0 +1,85 @@
+# Configuration for Artemis
+#
+# @api private
+class candlepin::certificates {
+  assert_private()
+
+  $config_dir = '/etc/candlepin'
+
+  $ca_key = "${config_dir}/certs/candlepin-ca.key"
+  $ca_cert = "${config_dir}/certs/candlepin-ca.crt"
+  $ca_key_password = $candlepin::ca_key_password
+  $crl_file = $candlepin::crl_file
+
+  file { $ca_cert:
+    ensure => file,
+    source => $candlepin::ca_cert,
+    mode   => '0440',
+    owner  => 'root',
+    group  => $candlepin::group,
+  }
+
+  file { $ca_key:
+    ensure    => file,
+    source    => $candlepin::ca_key,
+    mode      => '0440',
+    owner     => 'root',
+    group     => $candlepin::group,
+    show_diff => false,
+  }
+
+  file { $candlepin::truststore_password_path:
+    ensure    => file,
+    content   => $candlepin::truststore_password,
+    owner     => 'root',
+    group     => $candlepin::group,
+    mode      => '0440',
+    show_diff => false,
+  }
+
+  truststore { $candlepin::truststore:
+    ensure        => present,
+    password_file => $candlepin::truststore_password_path,
+    owner         => 'root',
+    group         => $candlepin::group,
+    mode          => '0640',
+  }
+
+  truststore_certificate { "${candlepin::truststore}:ca":
+    ensure        => present,
+    password_file => $candlepin::truststore_password_path,
+    certificate   => $candlepin::ca_cert,
+  }
+
+  truststore_certificate { "${candlepin::truststore}:artemis-client":
+    ensure        => present,
+    password_file => $candlepin::truststore_password_path,
+    certificate   => $candlepin::artemis_client_certificate,
+  }
+
+  file { $candlepin::keystore_password_path:
+    ensure    => file,
+    content   => $candlepin::keystore_password,
+    owner     => 'root',
+    group     => $candlepin::group,
+    mode      => '0440',
+    show_diff => false,
+  }
+
+  keystore { $candlepin::keystore:
+    ensure        => present,
+    password_file => $candlepin::truststore_password_path,
+    owner         => 'root',
+    group         => $candlepin::group,
+    mode          => '0640',
+  }
+
+  keystore_certificate { "${candlepin::keystore}:tomcat":
+    ensure        => present,
+    password_file => $candlepin::keystore_password_path,
+    certificate   => $candlepin::tomcat_ssl_cert,
+    private_key   => $candlepin::tomcat_ssl_key,
+    ca            => $candlepin::ca_cert,
+  }
+}
+

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,10 @@
 class candlepin::config {
   assert_private()
 
+  contain candlepin::certificates
+
+  $tomcat_config_dir = '/etc/tomcat'
+
   user { $candlepin::user:
     ensure => present,
     gid    => $candlepin::group,
@@ -25,7 +29,7 @@ class candlepin::config {
     group => $candlepin::group,
   }
 
-  file { '/etc/tomcat/server.xml':
+  file { "${tomcat_config_dir}/server.xml":
     ensure  => file,
     content => template('candlepin/tomcat/server.xml.erb'),
     mode    => '0644',
@@ -33,7 +37,7 @@ class candlepin::config {
     group   => 'root',
   }
 
-  file { '/etc/tomcat/tomcat.conf':
+  file { "${tomcat_config_dir}/tomcat.conf":
     ensure  => file,
     content => template('candlepin/tomcat/tomcat.conf.erb'),
     mode    => '0644',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,17 +50,8 @@
 # @param env_filtering_enabled
 #   If subscription filtering is done on a per environment basis
 #
-# @param keystore_file
-#   Tomcat keystore file to use
-#
 # @param keystore_password
 #   Password for keystore being used with Tomcat
-#
-# @param keystore_type
-#   Keystore type
-#
-# @param truststore_file
-#   Truststore file to use for Tomcat and Artemis
 #
 # @param truststore_password
 #   Password for truststore being used with Tomcat and Artemis
@@ -70,6 +61,12 @@
 #
 # @param ca_cert
 #   CA certificate file to use
+#
+# @param tomcat_ssl_cert
+#   The certificate to use for Tomcat server
+#
+# @param tomcat_ssl_key
+#   The private key to use for Tomcat server
 #
 # @param ca_key_password
 #   CA key password
@@ -157,6 +154,9 @@
 # @param artemis_client_dn
 #   Full DN for the client certificate used to talk to Artemis
 #
+# @param artemis_client_certificate
+#   Path to the client certificate used to talk to Artemis
+#
 # @param broker_config_file
 #   Config file for Artemis
 #
@@ -183,13 +183,12 @@ class candlepin (
   String $oauth_key = 'candlepin',
   String $oauth_secret = 'candlepin',
   Boolean $env_filtering_enabled = true,
-  Stdlib::Absolutepath $keystore_file = '/etc/candlepin/certs/keystore',
-  Optional[String] $keystore_password = undef,
-  String $keystore_type = 'PKCS12',
-  Stdlib::Absolutepath $truststore_file = '/etc/candlepin/certs/truststore',
-  Optional[String] $truststore_password = undef,
-  Stdlib::Absolutepath $ca_key = '/etc/candlepin/certs/candlepin-ca.key',
-  Stdlib::Absolutepath $ca_cert = '/etc/candlepin/certs/candlepin-ca.crt',
+  Optional[String] $keystore_password = $candlepin::params::keystore_password,
+  Optional[String] $truststore_password = $candlepin::params::truststore_password,
+  Stdlib::Absolutepath $ca_key = undef,
+  Stdlib::Absolutepath $ca_cert = undef,
+  Stdlib::Absolutepath $tomcat_ssl_cert = undef,
+  Stdlib::Absolutepath $tomcat_ssl_key = undef,
   Optional[String] $ca_key_password = undef,
   Array[String] $ciphers = $candlepin::params::ciphers,
   Array[String] $tls_versions = ['1.2'],
@@ -218,12 +217,19 @@ class candlepin (
   Stdlib::Host $artemis_host = 'localhost',
   Stdlib::Port $artemis_port = 61613,
   Variant[Deferred, String] $artemis_client_dn = 'CN=ActiveMQ Artemis Client, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ',
+  Stdlib::Absolutepath $artemis_client_certificate = undef,
   Stdlib::Absolutepath $broker_config_file = '/etc/candlepin/broker.xml',
   String $user = 'tomcat',
   String $group = 'tomcat',
 ) inherits candlepin::params {
 
   contain candlepin::service
+
+  $truststore = '/etc/candlepin/certs/truststore'
+  $truststore_password_path = '/etc/candlepin/certs/truststore_password-file'
+
+  $keystore = '/etc/candlepin/certs/keystore'
+  $keystore_password_path = '/etc/candlepin/certs/keystore_password-file'
 
   Anchor <| title == 'candlepin::repo' |> ->
   class { 'candlepin::install': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,11 @@ class candlepin::params {
   # this comes from keystore
   $db_password = extlib::cache_data('foreman_cache_data', 'candlepin_db_password', extlib::random_password(32))
 
+  $truststore_password = extlib::cache_data('candlepin', 'truststore_password', extlib::random_password(32))
+  $keystore_password = extlib::cache_data('candlepin', 'keystore_password', extlib::random_password(32))
+
+  $keystore_type = 'PKCS12'
+
   $ciphers = [
     'SSL_RSA_WITH_3DES_EDE_CBC_SHA',
     'TLS_RSA_WITH_AES_256_CBC_SHA',

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,10 @@
     {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 1.0.0 < 8.0.0"
+    },
+    {
+      "name": "katello/certs",
+      "version_requirement":">= 13.0.0 < 14.0.0"
     }
   ],
   "requirements": [

--- a/templates/broker.xml.erb
+++ b/templates/broker.xml.erb
@@ -12,7 +12,7 @@
 
         <acceptors>
             <acceptor name="in-vm">vm://0</acceptor>
-            <acceptor name="stomp">tcp://<%= scope['candlepin::artemis_host'] %>:<%= scope['candlepin::artemis_port'] %>?protocols=STOMP;useEpoll=false;sslEnabled=true;trustStorePath=<%= scope['candlepin::truststore_file'] %>;trustStorePassword=<%= scope['candlepin::truststore_password'] %>;keyStorePath=<%= scope['candlepin::keystore_file'] %>;keyStorePassword=<%= scope['candlepin::keystore_password'] %>;needClientAuth=true</acceptor>
+            <acceptor name="stomp">tcp://<%= scope['candlepin::artemis_host'] %>:<%= scope['candlepin::artemis_port'] %>?protocols=STOMP;useEpoll=false;sslEnabled=true;trustStorePath=<%= scope['candlepin::truststore'] %>;trustStorePassword=<%= scope['candlepin::truststore_password'] %>;keyStorePath=<%= scope['candlepin::keystore'] %>;keyStorePassword=<%= scope['candlepin::keystore_password'] %>;needClientAuth=true</acceptor>
         </acceptors>
 
         <security-enabled>true</security-enabled>

--- a/templates/candlepin.conf.erb
+++ b/templates/candlepin.conf.erb
@@ -19,11 +19,11 @@ candlepin.auth.oauth.consumer.<%= scope['candlepin::oauth_key'] %>.secret=<%= sc
 module.config.adapter_module=<%= scope['candlepin::adapter_module'] %>
 <%- end -%>
 
-candlepin.ca_key=<%= scope['candlepin::ca_key'] %>
-candlepin.ca_cert=<%= scope['candlepin::ca_cert'] %>
-candlepin.crl.file=<%= scope['candlepin::crl_file'] %>
-<% unless [nil, :undefined, :undef].include?(scope['candlepin::ca_key_password']) -%>
-candlepin.ca_key_password=<%= scope['candlepin::ca_key_password'] %>
+candlepin.ca_key=<%= scope['candlepin::certificates::ca_key'] %>
+candlepin.ca_cert=<%= scope['candlepin::certificates::ca_cert'] %>
+candlepin.crl.file=<%= scope['candlepin::certificates::crl_file'] %>
+<% unless [nil, :undefined, :undef].include?(scope['candlepin::certificates::ca_key_password']) -%>
+candlepin.ca_key_password=<%= scope['candlepin::certificates::ca_key_password'] %>
 <%- end -%>
 
 # Quartz schedule notation for how often to run the ExpiredPoolsJob

--- a/templates/tomcat/server.xml.erb
+++ b/templates/tomcat/server.xml.erb
@@ -80,10 +80,10 @@
                clientAuth="want"
                sslProtocol="<%= scope['::candlepin::tls_versions'].map { |version| "TLSv#{version}"}.join(",") %>"
                sslEnabledProtocols="<%= scope['::candlepin::tls_versions'].map { |version| "TLSv#{version}"}.join(",") %>"
-               keystoreFile="<%= scope['::candlepin::keystore_file'] %>"
+               keystoreFile="<%= scope['::candlepin::keystore'] %>"
                keystorePass="<%= scope['::candlepin::keystore_password'] %>"
                keystoreType="<%= scope['::candlepin::keystore_type'] %>"
-               truststoreFile="<%= scope['::candlepin::truststore_file'] %>"
+               truststoreFile="<%= scope['::candlepin::truststore'] %>"
                truststorePass="<%= scope['::candlepin::truststore_password'] %>"
                ciphers="<%= scope['::candlepin::ciphers'].join(",\n                    ") %>" />
 


### PR DESCRIPTION
This is a proof of concept to show off a design I have been thinking about in how we change certificate management within our modules. The idea here is to push the management of certificate stores (e.g. truststore, keystore) into the modules themselves. These stores often requirement permissions, user and group ownership to be set on them that is inherently managed by the module themselves. Thus the interface would focus saying what certificates to use and the module would handle ensuring they end up in the right format with the right permissions. Taking the example from `katello::candlepin` we would have:

```
  # Generate the needed certificates but do not try to manage the certificates
  # or their storage
  class { 'certs::candlepin':
    hostname => $katello::params::candlepin_host,
  } 

  # Declare candlepin class and pass it the certificates needed for the truststore
  # but as the certificate they are not as being needed for a truststore which is
  # more descriptive of the purpose
  class { 'candlepin':
    host                         => $katello::params::candlepin_host,
    ssl_port                     => $katello::params::candlepin_port,
    user_groups                  => $certs::candlepin::group,
    oauth_key                    => $katello::params::candlepin_oauth_key,
    oauth_secret                 => $katello::params::candlepin_oauth_secret,
    ca_key                       => $certs::candlepin::ca_key,
    ca_cert                      => $certs::candlepin::ca_cert,
    keystore_file                => $certs::candlepin::keystore,
    keystore_password            => $certs::candlepin::keystore_password,
    artemis_client_dn            => $certs::candlepin::artemis_client_dn,
    artemis_client_certificate => $certs::candlepin::artemis_client_certificate,
    artemis_client_ca_chain => $certs::candlepin::artemis_client_ca_chain,
    java_home                    => '/usr/lib/jvm/jre-11',
    java_package                 => 'java-11-openjdk',
    enable_basic_auth            => false,
    consumer_system_name_pattern => '.+',
    adapter_module               => 'org.candlepin.katello.KatelloModule',
    db_host                      => $db_host,
    db_port                      => $db_port,
    db_name                      => $db_name,
    db_user                      => $db_user,
    db_password                  => $db_password,
    db_ssl                       => $db_ssl,
    db_ssl_verify                => $db_ssl_verify,
    manage_db                    => $manage_db,
    subscribe                    => Class['certs', 'certs::candlepin'],
  }
```

Note this drops the use of these parameters:

```
    truststore_file              => $certs::candlepin::truststore,
    truststore_password          => $certs::candlepin::truststore_password,
```

And adds:

```
    artemis_client_certificate => $certs::candlepin::artemis_client_certificate,
    artemis_client_ca_chain => $certs::candlepin::artemis_client_ca_chain,
```

This means as a user of this module I do not have to go figure out truststore creation and management nor do I have to rely on the right file permissions for the service to work. Rather, I can focus on obtaining certificates and passing them along to the module and rely on it handling the internals for me.

I am looking towards a model that separates creation from management of certificates. Right now, puppet-certs does both in the same class which makes it hard for a user to bring their own PKI.