### PR TITLE
Remove qpid test fixture

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,6 @@ fixtures:
     extlib:     'https://github.com/voxpupuli/puppet-extlib'
     concat:     'https://github.com/puppetlabs/puppetlabs-concat'
     postgresql: 'https://github.com/puppetlabs/puppetlabs-postgresql.git'
-    qpid:       'https://github.com/theforeman/puppet-qpid.git'
     selinux_core:
       repo:           'https://github.com/puppetlabs/puppetlabs-selinux_core'
       puppet_version: '>= 6.0.0'


### PR DESCRIPTION
f8ec9a28b92ed66f247bb1ad0a79fcc4e2803d70 remove Qpid functionality was removed altogether. This also stops checking out the module in testing.