### PR TITLE
Fixes #32586: Add artemis_client_certificate parameter and calculate …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,9 @@ vendor/
 .ruby-*
 
 ## rspec
-spec/fixtures/
+spec/fixtures/modules/*
+spec/fixtures/manifests
+!spec/fixtures/modules/certificates
 junit/
 
 ## Puppet module

--- a/examples/artemis_client_cert.pp
+++ b/examples/artemis_client_cert.pp
@@ -1,0 +1,22 @@
+#
+# Create certificates then install candlepin
+#
+
+$server_fqdn = 'example01.example.com'
+
+class { 'certificates':
+  artemis_client_common_names => [$server_fqdn],
+} ->
+class { 'candlepin':
+  ca_key                              => $certificates::ca_key,
+  ca_cert                             => $certificates::ca_cert,
+  keystore_file                       => $certificates::keystore,
+  keystore_password                   => $certificates::keystore_password,
+  truststore_file                     => $certificates::truststore,
+  truststore_password                 => $certificates::truststore_password,
+  java_package                        => 'java-11-openjdk',
+  java_home                           => '/usr/lib/jvm/jre-11',
+  artemis_client_certificate_user_map => {
+    "${certificates::artemis_dir}/${server_fqdn}.crt" => $server_fqdn,
+  },
+}

--- a/examples/artemis_client_cert_multi_host.pp
+++ b/examples/artemis_client_cert_multi_host.pp
@@ -1,0 +1,24 @@
+#
+# Create certificates then install candlepin
+#
+
+$first_server_fqdn = 'example01.example.com'
+$second_server_fqdn = 'example02.example.com'
+
+class { 'certificates':
+  artemis_client_common_names => [$first_server_fqdn, $second_server_fqdn],
+} ->
+class { 'candlepin':
+  ca_key                              => $certificates::ca_key,
+  ca_cert                             => $certificates::ca_cert,
+  keystore_file                       => $certificates::keystore,
+  keystore_password                   => $certificates::keystore_password,
+  truststore_file                     => $certificates::truststore,
+  truststore_password                 => $certificates::truststore_password,
+  java_package                        => 'java-11-openjdk',
+  java_home                           => '/usr/lib/jvm/jre-11',
+  artemis_client_certificate_user_map => {
+    "${certificates::artemis_dir}/${first_server_fqdn}.crt"  => $first_server_fqdn,
+    "${certificates::artemis_dir}/${second_server_fqdn}.crt" => $second_server_fqdn,
+  },
+}

--- a/examples/artemis_client_cert_new_host.pp
+++ b/examples/artemis_client_cert_new_host.pp
@@ -1,0 +1,22 @@
+#
+# Create certificates then install candlepin
+#
+
+$server_fqdn = 'example02.example.com'
+
+class { 'certificates':
+  artemis_client_common_names => [$server_fqdn],
+} ->
+class { 'candlepin':
+  ca_key                              => $certificates::ca_key,
+  ca_cert                             => $certificates::ca_cert,
+  keystore_file                       => $certificates::keystore,
+  keystore_password                   => $certificates::keystore_password,
+  truststore_file                     => $certificates::truststore,
+  truststore_password                 => $certificates::truststore_password,
+  java_package                        => 'java-11-openjdk',
+  java_home                           => '/usr/lib/jvm/jre-11',
+  artemis_client_certificate_user_map => {
+    "${certificates::artemis_dir}/${server_fqdn}.crt" => $server_fqdn,
+  },
+}

--- a/examples/basic_candlepin.pp
+++ b/examples/basic_candlepin.pp
@@ -1,61 +1,14 @@
 #
 # Create certificates then install candlepin
 #
-
-$keydir = '/etc/candlepin/certs'
-$keystore = "${keydir}/keystore"
-$keystore_password = 'secret'
-$truststore = "${keydir}/truststore"
-$truststore_password = 'secret'
-$ca_key = "${keydir}/candlepin-ca.key"
-$ca_cert = "${keydir}/candlepin-ca.crt"
-
-exec { "/bin/mkdir -p ${keydir}":
-  creates => $keydir,
-} ->
-exec { 'Create CA key':
-  command => "/usr/bin/openssl genrsa -out '${ca_key}' 2048",
-  creates => $ca_key,
-  notify  => Service['tomcat'],
-} ->
-exec { 'Create CA certficate':
-  command => "/usr/bin/openssl req -new -x509 -key '${ca_key}' -out '${ca_cert}' -nodes -x509 -subj '/C=US/ST=North Carolina/L=Raleigh/O=CustomKatelloCA/CN=${facts['networking']['fqdn']}'",
-  creates => $ca_cert,
-  notify  => Service['tomcat'],
-} ->
-exec { 'Create keystore':
-  command => "/usr/bin/openssl pkcs12 -export -in '${ca_cert}' -inkey '${ca_key}' -out '${keystore}' -name tomcat -CAfile '${ca_cert}' -caname root -password 'pass:${keystore_password}'",
-  creates => $keystore,
-  notify  => Service['tomcat'],
-} ->
-package { ['java']: } ->
-exec { 'Create truststore':
-  command => "/usr/bin/keytool -import -v -keystore ${truststore} -alias candlepin-ca -file ${ca_cert} -noprompt -storepass ${truststore_password} -storetype pkcs12",
-  creates => $truststore,
-} ->
-file { $ca_key:
-  mode  => '0440',
-  group => 'tomcat',
-} ->
-file { $ca_cert:
-  mode  => '0440',
-  group => 'tomcat',
-} ->
-file { $keystore:
-  mode  => '0440',
-  group => 'tomcat',
-} ->
-file { $truststore:
-  mode  => '0440',
-  group => 'tomcat',
-} ->
+class { 'certificates': } ->
 class { 'candlepin':
-  ca_key              => $ca_key,
-  ca_cert             => $ca_cert,
-  keystore_file       => $keystore,
-  keystore_password   => $keystore_password,
-  truststore_file     => $truststore,
-  truststore_password => $truststore_password,
+  ca_key              => $certificates::ca_key,
+  ca_cert             => $certificates::ca_cert,
+  keystore_file       => $certificates::keystore,
+  keystore_password   => $certificates::keystore_password,
+  truststore_file     => $certificates::truststore,
+  truststore_password => $certificates::truststore_password,
   java_package        => 'java-11-openjdk',
   java_home           => '/usr/lib/jvm/jre-11',
   artemis_client_dn   => Deferred('pick', ['', 'CN=ActiveMQ Artemis Deferred, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ']),

--- a/files/tomcat/cert-roles.properties
+++ b/files/tomcat/cert-roles.properties
@@ -1,1 +1,0 @@
-candlepinEventsConsumer=katelloUser

--- a/lib/puppet/type/artemis_cert_users.rb
+++ b/lib/puppet/type/artemis_cert_users.rb
@@ -1,0 +1,84 @@
+Puppet::Type.newtype(:artemis_cert_users) do
+  desc 'Manages a CertificateLoginModule user configuration file for Artemis'
+
+  ensurable
+
+  newparam(:path, :namevar => true)
+
+  def exists?
+    self[:ensure] == :present
+  end
+
+  newparam(:certificate_users) do
+    desc "A map of certificates to users from which the client distinguished name will be calculated."
+    isrequired
+  end
+
+  newparam(:username) do
+    desc "The username to associate with the distinguished name."
+    isrequired
+  end
+
+  newparam(:owner, parent: Puppet::Type::File::Owner) do
+    desc "Specifies the owner of the file. Valid options: a string containing a username or integer containing a uid."
+  end
+
+  newparam(:group, parent: Puppet::Type::File::Group) do
+    desc "Specifies a permissions group for the file. Valid options: a string containing a group name or integer containing a gid."
+  end
+
+  newparam(:mode, parent: Puppet::Type::File::Mode) do
+    desc "Specifies the permissions mode of the file. Valid options: a string containing a permission mode value in octal notation."
+  end
+
+  def should_content
+    content = ''
+
+    self[:certificate_users].each do |certificate, user|
+      begin
+        cert = OpenSSL::X509::Certificate.new(File.read(certificate))
+        subject = cert.subject.to_s(OpenSSL::X509::Name::RFC2253)
+        subject = subject.split(',').join(', ')
+        content += "#{user}=#{subject}\n"
+      rescue OpenSSL::X509::CertificateError, Errno::ENOENT => e
+        Puppet.err("The file at #{self[:path]} could not be read or is not a valid x509 certificate: #{e}")
+        nil
+      end
+    end
+
+    content
+  end
+
+  def generate
+    file_opts = {
+      ensure: (self[:ensure] == :absent) ? :absent : :file,
+    }
+
+    [:path,
+     :owner,
+     :group,
+     :mode].each do |param|
+      file_opts[param] = self[param] unless self[param].nil?
+    end
+
+    excluded_metaparams = [:before, :notify, :require, :subscribe, :tag]
+
+    Puppet::Type.metaparams.each do |metaparam|
+      unless self[metaparam].nil? || excluded_metaparams.include?(metaparam)
+        file_opts[metaparam] = self[metaparam]
+      end
+    end
+
+    [Puppet::Type.type(:file).new(file_opts)]
+  end
+
+  def eval_generate
+    content = should_content
+
+    unless content.nil?
+      catalog.resource("File[#{self[:path]}]")[:content] = content
+    end
+
+    [catalog.resource("File[#{self[:path]}]")]
+  end
+end

--- a/manifests/artemis.pp
+++ b/manifests/artemis.pp
@@ -4,6 +4,8 @@
 class candlepin::artemis {
   assert_private()
 
+  $artemis_cert_dir = '/etc/candlepin/certs/artemis'
+
   file { $candlepin::broker_config_file:
     ensure  => file,
     content => template('candlepin/broker.xml.erb'),
@@ -20,20 +22,56 @@ class candlepin::artemis {
     group   => $candlepin::group,
   }
 
-  file { "${candlepin::catalina_home}/conf/cert-users.properties":
-    ensure  => file,
-    content => Deferred('inline_epp', ["katelloUser=<%= \$artemis_client_dn %>\n", {'artemis_client_dn' => $candlepin::artemis_client_dn}]),
-    mode    => '0640',
-    owner   => $candlepin::user,
-    group   => $candlepin::group,
+  if $candlepin::artemis_client_certificate_user_map {
+    file { $artemis_cert_dir:
+      ensure => directory,
+      owner  => $candlepin::user,
+      group  => $candlepin::group,
+    }
+
+    $candlepin::artemis_client_certificate_user_map.each |$certificate, $user| {
+      file { "${artemis_cert_dir}/${user}.crt":
+        ensure => file,
+        source => $certificate,
+        owner  => $candlepin::user,
+        group  => $candlepin::group,
+        mode   => '0640',
+      }
+    }
+
+    artemis_cert_users { "${candlepin::catalina_home}/conf/cert-users.properties":
+      ensure            => present,
+      certificate_users => $candlepin::artemis_client_certificate_user_map,
+      mode              => '0640',
+      owner             => $candlepin::user,
+      group             => $candlepin::group,
+    }
+  } elsif $candlepin::artemis_client_dn {
+    file { "${candlepin::catalina_home}/conf/cert-users.properties":
+      ensure  => file,
+      content => Deferred('inline_epp', ["katelloUser=<%= \$artemis_client_dn %>\n", {'artemis_client_dn' => $candlepin::artemis_client_dn}]),
+      mode    => '0640',
+      owner   => $candlepin::user,
+      group   => $candlepin::group,
+    }
   }
 
-  file { "${candlepin::catalina_home}/conf/cert-roles.properties":
-    ensure  => file,
-    content => file('candlepin/tomcat/cert-roles.properties'),
-    mode    => '0640',
-    owner   => $candlepin::user,
-    group   => $candlepin::group,
+  if $candlepin::artemis_client_dn {
+    $artemis_users = ['katelloUser']
+  } elsif $candlepin::artemis_client_certificate_user_map {
+    $artemis_users = $candlepin::artemis_client_certificate_user_map.map |$certificate, $user| {
+      $user
+    }
+  }
+
+  if $candlepin::artemis_client_dn or $candlepin::artemis_client_certificate_user_map {
+    file { "${candlepin::catalina_home}/conf/cert-roles.properties":
+      ensure  => file,
+      content => template('candlepin/tomcat/cert-roles.properties.erb'),
+      mode    => '0640',
+      owner   => $candlepin::user,
+      group   => $candlepin::group,
+    }
   }
 
   file { "${candlepin::catalina_home}/conf/conf.d/jaas.conf":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -157,6 +157,9 @@
 # @param artemis_client_dn
 #   Full DN for the client certificate used to talk to Artemis
 #
+# @param artemis_client_certificate_user_map
+#   Mapping of certificate to Artemis user for configuring roles in Artemis.
+#
 # @param broker_config_file
 #   Config file for Artemis
 #
@@ -217,13 +220,18 @@ class candlepin (
   String $certificate_revocation_list_task_schedule = '0 0 0 1 1 ?',
   Stdlib::Host $artemis_host = 'localhost',
   Stdlib::Port $artemis_port = 61613,
-  Variant[Deferred, String] $artemis_client_dn = 'CN=ActiveMQ Artemis Client, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ',
+  Optional[Variant[Deferred, String]] $artemis_client_dn = undef,
+  Optional[Hash[String[1], String[1]]] $artemis_client_certificate_user_map = undef,
   Stdlib::Absolutepath $broker_config_file = '/etc/candlepin/broker.xml',
   String $user = 'tomcat',
   String $group = 'tomcat',
 ) inherits candlepin::params {
 
   contain candlepin::service
+
+  if $artemis_client_dn and $artemis_client_certificate_user_map {
+    fail('Both $artemis_client_dn and $artemis_client_certificate_user_map cannot be supplied. Please pass only one.')
+  }
 
   Anchor <| title == 'candlepin::repo' |> ->
   class { 'candlepin::install': } ~>

--- a/spec/acceptance/artemis_client_cert_spec.rb
+++ b/spec/acceptance/artemis_client_cert_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper_acceptance'
+
+#TODO: Add Artemis listening test https://projects.theforeman.org/issues/29561
+
+describe 'candlepin works' do
+  context 'initial certificates' do
+    include_examples 'the example', 'artemis_client_cert.pp'
+
+    describe port(8443) do
+      it { is_expected.to be_listening }
+    end
+
+    describe command('curl -k -s -o /dev/null -w \'%{http_code}\' https://localhost:8443/candlepin/status') do
+      its(:stdout) { should eq "200" }
+    end
+
+    describe command('nmap --script +ssl-enum-ciphers localhost -p 8443') do
+      # We don't enable TLSv1.3 by default yet. TLSv1.3 support was added in tomcat 7.0.92
+      # But tomcat 7.0.76 is the latest version available on EL7
+      its(:stdout) { should_not match(/TLSv1\.3/) }
+
+      # Test that TLSv1.2 is enabled
+      its(:stdout) { should match(/TLSv1\.2/) }
+
+      # Test that older TLS versions are disabled
+      its(:stdout) { should_not match(/TLSv1\.1/) }
+      its(:stdout) { should_not match(/TLSv1\.0/) }
+
+      # Test that the least cipher strength is "strong" or "A"
+      its(:stdout) { should match(/least strength: (A|strong)/) }
+    end
+
+    describe file("/usr/share/tomcat/conf/cert-users.properties") do
+      it { should be_file }
+      it { should be_mode 640 }
+      it { should be_owned_by 'tomcat' }
+      it { should be_grouped_into 'tomcat' }
+      its(:content) { should eq("example01.example.com=CN=example01.example.com, ST=North Carolina, C=US\n") }
+    end
+
+    describe file("/usr/share/tomcat/conf/cert-roles.properties") do
+      it { should be_file }
+      it { should be_mode 640 }
+      it { should be_owned_by 'tomcat' }
+      it { should be_grouped_into 'tomcat' }
+      its(:content) { should eq("candlepinEventsConsumer=example01.example.com\n") }
+    end
+  end
+
+  context 'with new certificates' do
+    before(:context) do
+      on default, 'rm -rf /etc/pki/artemis'
+    end
+
+    include_examples 'the example', 'artemis_client_cert_new_host.pp'
+
+    describe port(8443) do
+      it { is_expected.to be_listening }
+    end
+
+    describe command('curl -k -s -o /dev/null -w \'%{http_code}\' https://localhost:8443/candlepin/status') do
+      its(:stdout) { should eq "200" }
+    end
+
+    describe command('nmap --script +ssl-enum-ciphers localhost -p 8443') do
+      # We don't enable TLSv1.3 by default yet. TLSv1.3 support was added in tomcat 7.0.92
+      # But tomcat 7.0.76 is the latest version available on EL7
+      its(:stdout) { should_not match(/TLSv1\.3/) }
+
+      # Test that TLSv1.2 is enabled
+      its(:stdout) { should match(/TLSv1\.2/) }
+
+      # Test that older TLS versions are disabled
+      its(:stdout) { should_not match(/TLSv1\.1/) }
+      its(:stdout) { should_not match(/TLSv1\.0/) }
+
+      # Test that the least cipher strength is "strong" or "A"
+      its(:stdout) { should match(/least strength: (A|strong)/) }
+    end
+
+    describe file("/usr/share/tomcat/conf/cert-users.properties") do
+      it { should be_file }
+      it { should be_mode 640 }
+      it { should be_owned_by 'tomcat' }
+      it { should be_grouped_into 'tomcat' }
+      its(:content) { should eq("example02.example.com=CN=example02.example.com, ST=North Carolina, C=US\n") }
+    end
+
+    describe file("/usr/share/tomcat/conf/cert-roles.properties") do
+      it { should be_file }
+      it { should be_mode 640 }
+      it { should be_owned_by 'tomcat' }
+      it { should be_grouped_into 'tomcat' }
+      its(:content) { should eq("candlepinEventsConsumer=example02.example.com\n") }
+    end
+  end
+
+  context 'with multiple certificates' do
+    before(:context) do
+      on default, 'rm -rf /etc/pki/artemis'
+    end
+
+    include_examples 'the example', 'artemis_client_cert_multi_host.pp'
+
+    describe port(8443) do
+      it { is_expected.to be_listening }
+    end
+
+    describe command('curl -k -s -o /dev/null -w \'%{http_code}\' https://localhost:8443/candlepin/status') do
+      its(:stdout) { should eq "200" }
+    end
+
+    describe command('nmap --script +ssl-enum-ciphers localhost -p 8443') do
+      # We don't enable TLSv1.3 by default yet. TLSv1.3 support was added in tomcat 7.0.92
+      # But tomcat 7.0.76 is the latest version available on EL7
+      its(:stdout) { should_not match(/TLSv1\.3/) }
+
+      # Test that TLSv1.2 is enabled
+      its(:stdout) { should match(/TLSv1\.2/) }
+
+      # Test that older TLS versions are disabled
+      its(:stdout) { should_not match(/TLSv1\.1/) }
+      its(:stdout) { should_not match(/TLSv1\.0/) }
+
+      # Test that the least cipher strength is "strong" or "A"
+      its(:stdout) { should match(/least strength: (A|strong)/) }
+    end
+
+    describe file("/usr/share/tomcat/conf/cert-users.properties") do
+      it { should be_file }
+      it { should be_mode 640 }
+      it { should be_owned_by 'tomcat' }
+      it { should be_grouped_into 'tomcat' }
+      its(:content) { should eq("example01.example.com=CN=example01.example.com, ST=North Carolina, C=US\nexample02.example.com=CN=example02.example.com, ST=North Carolina, C=US\n") }
+    end
+
+    describe file("/usr/share/tomcat/conf/cert-roles.properties") do
+      it { should be_file }
+      it { should be_mode 640 }
+      it { should be_owned_by 'tomcat' }
+      it { should be_grouped_into 'tomcat' }
+      its(:content) { should eq("candlepinEventsConsumer=example01.example.com,example02.example.com\n") }
+    end
+  end
+end

--- a/spec/fixtures/modules/certificates/manifests/artemis_certificate.pp
+++ b/spec/fixtures/modules/certificates/manifests/artemis_certificate.pp
@@ -1,0 +1,25 @@
+define certificates::artemis_certificate (
+  $dir,
+  $common_name,
+  $ca_cert,
+  $ca_key,
+) {
+
+  $key = "${dir}/${common_name}.key"
+  $req = "${dir}/${common_name}.req"
+  $certificate = "${dir}/${common_name}.crt"
+
+  exec { "Create ${common_name} artemis client key":
+    command => "/usr/bin/openssl genrsa -out '${key}' 2048",
+    creates => $key,
+  } ->
+  exec { "Create ${common_name} artemis client certificate signing request":
+    command => "/usr/bin/openssl req -new -key '${key}' -out '${req}' -subj '/C=US/ST=North Carolina/CN=${common_name}'",
+    creates => $certificate,
+  } ->
+  exec { "Create ${common_name} artemis client certificate":
+    command => "/usr/bin/openssl x509 -req -in '${req}' -out '${certificate}' -CA '${ca_cert}' -CAkey '${ca_key}' -set_serial 1",
+    creates => $certificate,
+  }
+
+}

--- a/spec/fixtures/modules/certificates/manifests/init.pp
+++ b/spec/fixtures/modules/certificates/manifests/init.pp
@@ -1,0 +1,68 @@
+# Create certificates
+class certificates (
+  $artemis_client_common_names = [$facts['networking']['fqdn']],
+) {
+  $keydir = '/etc/candlepin/certs'
+  $keystore = "${keydir}/keystore"
+  $keystore_password = 'secret'
+  $truststore = "${keydir}/truststore"
+  $truststore_password = 'secret'
+  $ca_key = "${keydir}/candlepin-ca.key"
+  $ca_cert = "${keydir}/candlepin-ca.crt"
+
+  $artemis_dir = '/etc/pki/artemis'
+
+  exec { "/bin/mkdir -p ${keydir}":
+    creates => $keydir,
+  } ->
+  exec { 'Create CA key':
+    command => "/usr/bin/openssl genrsa -out '${ca_key}' 2048",
+    creates => $ca_key,
+    notify  => Service['tomcat'],
+  } ->
+  exec { 'Create CA certificate':
+    command => "/usr/bin/openssl req -new -x509 -key '${ca_key}' -out '${ca_cert}' -nodes -x509 -subj '/C=US/ST=North Carolina/L=Raleigh/O=CustomKatelloCA/CN=${facts['networking']['fqdn']}'",
+    creates => $ca_cert,
+    notify  => Service['tomcat'],
+  } ->
+  exec { 'Create keystore':
+    command => "/usr/bin/openssl pkcs12 -export -in '${ca_cert}' -inkey '${ca_key}' -out '${keystore}' -name tomcat -CAfile '${ca_cert}' -caname root -password 'pass:${keystore_password}'",
+    creates => $keystore,
+    notify  => Service['tomcat'],
+  } ->
+  package { ['java']: } ->
+  exec { 'Create truststore':
+    command => "/usr/bin/keytool -import -v -keystore ${truststore} -alias candlepin-ca -file ${ca_cert} -noprompt -storepass ${truststore_password} -storetype pkcs12",
+    creates => $truststore,
+  } ->
+  file { $ca_key:
+    mode  => '0440',
+    group => 'tomcat',
+  } ->
+  file { $ca_cert:
+    mode  => '0440',
+    group => 'tomcat',
+  } ->
+  file { $keystore:
+    mode  => '0440',
+    group => 'tomcat',
+  } ->
+  file { $truststore:
+    mode  => '0440',
+    group => 'tomcat',
+  }
+
+  file { $artemis_dir:
+    ensure => directory,
+  }
+
+  $artemis_client_common_names.each |$common_name| {
+    certificates::artemis_certificate { $common_name:
+      common_name => $common_name,
+      dir         => $artemis_dir,
+      ca_cert     => $ca_cert,
+      ca_key      => $ca_key,
+      require      => [File[$artemis_dir], Exec['Create CA certificate']]
+    }
+  }
+}

--- a/spec/fixtures/modules/certificates/metadata.json
+++ b/spec/fixtures/modules/certificates/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-certificates",
+  "version": "0.0.1",
+  "author": "theforeman",
+  "summary": "For testing purposes only",
+  "license": "GPL-3.0+",
+  "source": "test",
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.25.0 < 8.0.0"
+    }
+  ]
+}

--- a/templates/tomcat/cert-roles.properties.erb
+++ b/templates/tomcat/cert-roles.properties.erb
@@ -1,0 +1,1 @@
+candlepinEventsConsumer=<%= @artemis_users.join(',') %>


### PR DESCRIPTION
…client DN

This change allows users to pass a mapping of certificate to user to
associate certificates that can consume Artemis events. This, for example,
could allow multiple servers to be configured to consume events, or
multiple certificates for migration.