### PR TITLE
Refs #32585: Support artemis_client_dn as a Deferred object

### DIFF
--- a/examples/basic_candlepin.pp
+++ b/examples/basic_candlepin.pp
@@ -58,4 +58,5 @@ class { 'candlepin':
   truststore_password => $truststore_password,
   java_package        => 'java-11-openjdk',
   java_home           => '/usr/lib/jvm/jre-11',
+  artemis_client_dn   => Deferred('pick', ['', 'CN=ActiveMQ Artemis Deferred, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ']),
 }

--- a/manifests/artemis.pp
+++ b/manifests/artemis.pp
@@ -22,7 +22,7 @@ class candlepin::artemis {
 
   file { "${candlepin::catalina_home}/conf/cert-users.properties":
     ensure  => file,
-    content => template('candlepin/tomcat/cert-users.properties.erb'),
+    content => Deferred('inline_epp', ["katelloUser=<%= \$artemis_client_dn %>\n", {'artemis_client_dn' => $candlepin::artemis_client_dn}]),
     mode    => '0640',
     owner   => $candlepin::user,
     group   => $candlepin::group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -217,7 +217,7 @@ class candlepin (
   String $certificate_revocation_list_task_schedule = '0 0 0 1 1 ?',
   Stdlib::Host $artemis_host = 'localhost',
   Stdlib::Port $artemis_port = 61613,
-  String $artemis_client_dn = 'CN=ActiveMQ Artemis Client, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ',
+  Variant[Deferred, String] $artemis_client_dn = 'CN=ActiveMQ Artemis Client, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ',
   Stdlib::Absolutepath $broker_config_file = '/etc/candlepin/broker.xml',
   String $user = 'tomcat',
   String $group = 'tomcat',

--- a/spec/acceptance/basic_candlepin_spec.rb
+++ b/spec/acceptance/basic_candlepin_spec.rb
@@ -28,4 +28,12 @@ describe 'candlepin works' do
     # Test that the least cipher strength is "strong" or "A"
     its(:stdout) { should match(/least strength: (A|strong)/) }
   end
+
+  describe file("/usr/share/tomcat/conf/cert-users.properties") do
+    it { should be_file }
+    it { should be_mode 640 }
+    it { should be_owned_by 'tomcat' }
+    it { should be_grouped_into 'tomcat' }
+    its(:content) { should eq("katelloUser=CN=ActiveMQ Artemis Deferred, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ\n") }
+  end
 end

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -58,9 +58,12 @@ describe 'candlepin' do
         end
 
         it { is_expected.to contain_file('/usr/share/tomcat/conf/login.config') }
-        it { is_expected.to contain_file('/usr/share/tomcat/conf/cert-users.properties') }
         it { is_expected.to contain_file('/usr/share/tomcat/conf/cert-roles.properties') }
         it { is_expected.to contain_file('/usr/share/tomcat/conf/conf.d/jaas.conf') }
+        it do
+          is_expected.to contain_file('/usr/share/tomcat/conf/cert-users.properties').
+            with_content("katelloUser=CN=ActiveMQ Artemis Client, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ\n")
+        end
 
         it { is_expected.to contain_file('/etc/candlepin/broker.xml') }
 

--- a/templates/tomcat/cert-users.properties.erb
+++ b/templates/tomcat/cert-users.properties.erb
@@ -1,1 +1,0 @@
-katelloUser=<%= scope['::candlepin::artemis_client_dn'] %>


### PR DESCRIPTION
Allowing a Deferred object to be passed gives the opportunity
for the artemis_client_dn to be calculated on the agent often
where the certificate is present.