### PR TITLE
Fixes #33321 - Update job scheduling config options for correctness

### DIFF
--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -38,8 +38,8 @@ describe 'candlepin' do
             'candlepin.ca_cert=/etc/candlepin/certs/candlepin-ca.crt',
             'candlepin.crl.file=/var/lib/candlepin/candlepin-crl.crl',
             'log4j.logger.org.hibernate.internal.SessionImpl=ERROR',
-            'pinsetter.org.candlepin.pinsetter.tasks.ExpiredPoolsJob.schedule=0 0 0 * * ?',
-            'pinsetter.org.candlepin.pinsetter.tasks.CertificateRevocationListTask.schedule=0 0 0 1 1 ?',
+            'candlepin.async.jobs.ExpiredPoolsCleanupJob.schedule=0 0 0 * * ?',
+            'candlepin.async.jobs.CRLUpdateJob.schedule=0 0 0 1 1 ?',
             'candlepin.audit.hornetq.config_path=/etc/candlepin/broker.xml',
           ])
         end

--- a/templates/candlepin.conf.erb
+++ b/templates/candlepin.conf.erb
@@ -26,10 +26,8 @@ candlepin.crl.file=<%= scope['candlepin::crl_file'] %>
 candlepin.ca_key_password=<%= scope['candlepin::ca_key_password'] %>
 <%- end -%>
 
-# Quartz schedule notation for how often to run the ExpiredPoolsJob
-pinsetter.org.candlepin.pinsetter.tasks.ExpiredPoolsJob.schedule=<%= scope['candlepin::expired_pools_schedule'] %>
-
-pinsetter.org.candlepin.pinsetter.tasks.CertificateRevocationListTask.schedule=<%= scope['candlepin::certificate_revocation_list_task_schedule'] %>
+candlepin.async.jobs.ExpiredPoolsCleanupJob.schedule=<%= scope['candlepin::expired_pools_schedule'] %>
+candlepin.async.jobs.CRLUpdateJob.schedule=<%= scope['candlepin::certificate_revocation_list_task_schedule'] %>
 
 # Required for https://hibernate.atlassian.net/browse/HHH-12927
 log4j.logger.org.hibernate.internal.SessionImpl=ERROR


### PR DESCRIPTION
Pinsetter was removed a while ago and these config options changed. The replacements appear to do the trick:

```
2021-08-23 14:24:34,917 [thread=localhost-startStop-1] [=, org=, csid=] INFO  org.candlepin.async.JobManager - Removed existing schedule for job: CRLUpdateJob
2021-08-23 14:24:34,935 [thread=localhost-startStop-1] [=, org=, csid=] INFO  org.candlepin.async.JobManager - Removed existing schedule for job: ExpiredPoolsCleanupJob
2021-08-23 14:24:34,955 [thread=localhost-startStop-1] [=, org=, csid=] INFO  org.candlepin.async.JobManager - Scheduled job "CRLUpdateJob" with cron schedule: 1 0 0 1 1 ?
2021-08-23 14:24:34,964 [thread=localhost-startStop-1] [=, org=, csid=] INFO  org.candlepin.async.JobManager - Scheduled job "ExpiredPoolsCleanupJob" with cron schedule: 1 0 0 * * 

```