### PR TITLE
Remove obsolete CRLUpdateJob options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,9 +145,6 @@
 # @param expired_pools_schedule
 #   Quartz schedule notation for how often to run the ExpiredPoolsJob
 #
-# @param certificate_revocation_list_task_schedule
-#   Quartz schedule notation for how often to run CRL generation
-#
 # @param artemis_port
 #   Port to expose Artemis on
 #
@@ -214,7 +211,6 @@ class candlepin (
   Boolean $security_manager = false,
   Optional[Integer[0]] $shutdown_wait = undef,
   String $expired_pools_schedule = '0 0 0 * * ?',
-  String $certificate_revocation_list_task_schedule = '0 0 0 1 1 ?',
   Stdlib::Host $artemis_host = 'localhost',
   Stdlib::Port $artemis_port = 61613,
   Variant[Deferred, String] $artemis_client_dn = 'CN=ActiveMQ Artemis Client, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ',

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -39,7 +39,6 @@ describe 'candlepin' do
             'candlepin.crl.file=/var/lib/candlepin/candlepin-crl.crl',
             'log4j.logger.org.hibernate.internal.SessionImpl=ERROR',
             'candlepin.async.jobs.ExpiredPoolsCleanupJob.schedule=0 0 0 * * ?',
-            'candlepin.async.jobs.CRLUpdateJob.schedule=0 0 0 1 1 ?',
             'candlepin.audit.hornetq.config_path=/etc/candlepin/broker.xml',
           ])
         end

--- a/templates/candlepin.conf.erb
+++ b/templates/candlepin.conf.erb
@@ -27,7 +27,6 @@ candlepin.ca_key_password=<%= scope['candlepin::ca_key_password'] %>
 <%- end -%>
 
 candlepin.async.jobs.ExpiredPoolsCleanupJob.schedule=<%= scope['candlepin::expired_pools_schedule'] %>
-candlepin.async.jobs.CRLUpdateJob.schedule=<%= scope['candlepin::certificate_revocation_list_task_schedule'] %>
 
 # Required for https://hibernate.atlassian.net/browse/HHH-12927
 log4j.logger.org.hibernate.internal.SessionImpl=ERROR


### PR DESCRIPTION
The next (or otherwise upcoming) removes the CRLUpdateJob in favor of CertificateUpdateJob. The new job doesn't write any sort of CRL so we don't need to disable it.

Opening this as a draft so it doesn't get merged and so I don't forget to have this merged when the time comes :)