### PR TITLE
Disable FIPS support within Tomcat Java environment

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,7 +165,7 @@
 #
 # @param disable_fips
 #   Disable FIPS within the Java environment for Tomcat explicitly.
-#   When set to false no flag is added and system configuration is used.
+#   When set to false, no flag is added. Then on FIPS enabled systems, a Candlepin build that supports FIPS is required.
 #
 class candlepin (
   Boolean $manage_db = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,6 +163,10 @@
 # @param group
 #   Primary group for the Candlepin user
 #
+# @param disable_fips
+#   Disable FIPS within the Java environment for Tomcat explicitly.
+#   When set to false no flag is added and system configuration is used.
+#
 class candlepin (
   Boolean $manage_db = true,
   Boolean $init_db = true,
@@ -217,6 +221,7 @@ class candlepin (
   Stdlib::Absolutepath $broker_config_file = '/etc/candlepin/broker.xml',
   String $user = 'tomcat',
   String $group = 'tomcat',
+  Boolean $disable_fips = true,
 ) inherits candlepin::params {
 
   contain candlepin::service

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -51,7 +51,7 @@ describe 'candlepin' do
             'JAVA_HOME="/usr/lib/jvm/jre"',
             'CATALINA_HOME="/usr/share/tomcat"',
             'CATALINA_TMPDIR="/var/cache/tomcat/temp"',
-            'JAVA_OPTS="-Xms1024m -Xmx4096m"',
+            'JAVA_OPTS="-Xms1024m -Xmx4096m -Dcom.redhat.fips=false"',
             'SECURITY_MANAGER="0"',
           ])
         end

--- a/templates/tomcat/tomcat.conf.erb
+++ b/templates/tomcat/tomcat.conf.erb
@@ -30,7 +30,7 @@ CATALINA_HOME="<%= scope.lookupvar('::candlepin::catalina_home') %>"
 CATALINA_TMPDIR="<%= scope.lookupvar('::candlepin::catalina_tmpdir') %>"
 
 # You can pass some parameters to java here if you wish to
-JAVA_OPTS="<%= scope.lookupvar('::candlepin::java_opts') %>"
+JAVA_OPTS="<%= scope.lookupvar('::candlepin::java_opts') %><%= scope.lookupvar('::candlepin::disable_fips') ? ' -Dcom.redhat.fips=false' : '' %>"
 
 # You can change your tomcat locale here
 <% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar('::candlepin::lang')) %>


### PR DESCRIPTION
On EL8 FIPS enabled systems, Candlepin cannot run with FIPS enabled
within the Java stack. The solution is to turn off FIPS within the Tomcat
environment but leave it enabled for the system itself. This mirrors
the behavior on EL7 FIPS mode and is required until Candlepin can
adopt to working natively in a FIPS enabled Java environment.