### PR TITLE
Fixes #30366 - Candlepin config file owned by root

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,8 +20,8 @@ class candlepin::config {
   }
 
   concat{ $candlepin::candlepin_conf_file:
-    mode  => '0600',
-    owner => $candlepin::user,
+    mode  => '0640',
+    owner => 'root',
     group => $candlepin::group,
   }
 


### PR DESCRIPTION
Candlepin doesn't need to modify the configuration file and this means it's more secure.