### PR TITLE
Remove obsolete crl option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,9 +41,6 @@
 # @param db_password
 #   The Candlepin database password
 #
-# @param crl_file
-#   The Certificate Revocation File for Candlepin
-#
 # @param user_groups
 #   The user groups for the Candlepin tomcat user
 #
@@ -182,7 +179,6 @@ class candlepin (
   String $db_name = 'candlepin',
   String $db_user = 'candlepin',
   Variant[Sensitive[String], String] $db_password = $candlepin::params::db_password,
-  Stdlib::Absolutepath $crl_file = '/var/lib/candlepin/candlepin-crl.crl',
   Variant[Array[String], String] $user_groups = [],
   Stdlib::Absolutepath $log_dir = '/var/log/candlepin',
   String $oauth_key = 'candlepin',

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -36,7 +36,6 @@ describe 'candlepin' do
             'candlepin.auth.oauth.consumer.candlepin.secret=candlepin',
             'candlepin.ca_key=/etc/candlepin/certs/candlepin-ca.key',
             'candlepin.ca_cert=/etc/candlepin/certs/candlepin-ca.crt',
-            'candlepin.crl.file=/var/lib/candlepin/candlepin-crl.crl',
             'log4j.logger.org.hibernate.internal.SessionImpl=ERROR',
             'candlepin.async.jobs.ExpiredPoolsCleanupJob.schedule=0 0 0 * * ?',
             'candlepin.audit.hornetq.config_path=/etc/candlepin/broker.xml',

--- a/templates/candlepin.conf.erb
+++ b/templates/candlepin.conf.erb
@@ -21,7 +21,6 @@ module.config.adapter_module=<%= scope['candlepin::adapter_module'] %>
 
 candlepin.ca_key=<%= scope['candlepin::ca_key'] %>
 candlepin.ca_cert=<%= scope['candlepin::ca_cert'] %>
-candlepin.crl.file=<%= scope['candlepin::crl_file'] %>
 <% unless [nil, :undefined, :undef].include?(scope['candlepin::ca_key_password_unsensitive']) -%>
 candlepin.ca_key_password=<%= scope['candlepin::ca_key_password_unsensitive'] %>
 <%- end -%>


### PR DESCRIPTION
- As of versions candlepin-4.0.8-1 and candlepin-4.1.6-1 the
  CRL file no longer exists and this option is obsolete