### PR TITLE
Enable TLS 1.3 default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -204,7 +204,7 @@ class candlepin (
   Stdlib::Absolutepath $ca_cert = '/etc/candlepin/certs/candlepin-ca.crt',
   Optional[Variant[Sensitive[String], String]] $ca_key_password = undef,
   Array[String] $ciphers = $candlepin::params::ciphers,
-  Array[String] $tls_versions = ['1.2'],
+  Array[String] $tls_versions = ['1.2', '1.3'],
   Optional[String[1]] $java_package = undef,
   String $version = 'present',
   String $wget_version = 'present',


### PR DESCRIPTION
TLS version 1.3 is the latest TLS version. Now that we've dropped EL7 support this may be supported. Currently a draft since I don't know if it really does work. If it does, I'll also create a Redmine issue for this.

Came from https://bugzilla.redhat.com/show_bug.cgi?id=2117842