### PR TITLE
Fixes #35699 - Introduce a parameter to configure logging

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,9 @@
 # @param log_dir
 #   Directory for Candlepin logs
 #
+# @param loggers
+#   Set the log levels for loggers
+#
 # @param env_filtering_enabled
 #   If subscription filtering is done on a per environment basis
 #
@@ -167,6 +170,13 @@
 #   Disable FIPS within the Java environment for Tomcat explicitly.
 #   When set to false, no flag is added. Then on FIPS enabled systems, a Candlepin build that supports FIPS is required.
 #
+# @example Set debug logging
+#   class { 'candlepin':
+#     loggers => {
+#       'org.candlepin' => 'DEBUG',
+#     },
+#   }
+#
 class candlepin (
   Boolean $manage_db = true,
   Boolean $init_db = true,
@@ -181,6 +191,7 @@ class candlepin (
   Variant[Sensitive[String], String] $db_password = $candlepin::params::db_password,
   Variant[Array[String], String] $user_groups = [],
   Stdlib::Absolutepath $log_dir = '/var/log/candlepin',
+  Hash[String[1], Candlepin::LogLevel] $loggers = {},
   String $oauth_key = 'candlepin',
   String $oauth_secret = 'candlepin',
   Boolean $env_filtering_enabled = true,

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -31,7 +31,6 @@ describe 'candlepin' do
             'candlepin.auth.oauth.consumer.candlepin.secret=candlepin',
             'candlepin.ca_key=/etc/candlepin/certs/candlepin-ca.key',
             'candlepin.ca_cert=/etc/candlepin/certs/candlepin-ca.crt',
-            'log4j.logger.org.hibernate.internal.SessionImpl=ERROR',
             'candlepin.async.jobs.ExpiredPoolsCleanupJob.schedule=0 0 0 * * ?',
             'candlepin.audit.hornetq.config_path=/etc/candlepin/broker.xml',
           ])
@@ -239,6 +238,43 @@ describe 'candlepin' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.not_to contain_selboolean('candlepin_can_bind_activemq_port') }
           it { is_expected.not_to contain_package('candlepin-selinux') }
+        end
+      end
+
+      describe 'with additional logging' do
+        describe 'with org.candlepin set to DEBUG' do
+          let(:params) do
+            {
+              loggers: {
+                'org.candlepin' => 'DEBUG',
+              },
+            }
+          end
+
+          it do
+            is_expected.to contain_concat__fragment('General Config')
+              .with_content(%r{^log4j\.logger\.org\.candlepin=DEBUG$})
+          end
+        end
+
+        describe 'with various loggers set' do
+          let(:params) do
+            {
+              loggers: {
+                'org.candlepin'                             => 'DEBUG',
+                'org.candlepin.resource.ConsumerResource'   => 'WARN',
+                'org.candlepin.resource.HypervisorResource' => 'WARN',
+                'org.hibernate.internal.SessionImpl'        => 'FATAL',
+              },
+            }
+          end
+
+          it do
+            is_expected.to contain_concat__fragment('General Config')
+              .with_content(%r{^log4j\.logger\.org\.candlepin=DEBUG$})
+              .with_content(%r{^log4j\.logger\.org\.candlepin\.resource\.ConsumerResource=WARN$})
+              .with_content(%r{^log4j\.logger\.org\.candlepin\.resource\.HypervisorResource=WARN$})
+          end
         end
       end
 

--- a/templates/candlepin.conf.erb
+++ b/templates/candlepin.conf.erb
@@ -26,9 +26,9 @@ candlepin.ca_key_password=<%= scope['candlepin::ca_key_password_unsensitive'] %>
 <%- end -%>
 
 candlepin.async.jobs.ExpiredPoolsCleanupJob.schedule=<%= scope['candlepin::expired_pools_schedule'] %>
+<% if scope['candlepin::loggers'].any? -%>
 
-# Required for https://hibernate.atlassian.net/browse/HHH-12927
-log4j.logger.org.hibernate.internal.SessionImpl=ERROR
-
-# uncomment to enable debug logging in candlepin.log:
-#log4j.logger.org.candlepin=DEBUG
+<% scope['candlepin::loggers'].each do |logger, log_level| -%>
+log4j.logger.<%= logger %>=<%= log_level %>
+<% end -%>
+<% end -%>

--- a/types/loglevel.pp
+++ b/types/loglevel.pp
@@ -1,0 +1,2 @@
+# @summary A log4j log level
+type Candlepin::LogLevel = Enum['ALL', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL', 'OFF', 'TRACE']


### PR DESCRIPTION
This came up via https://github.com/theforeman/foreman-documentation/pull/1715 where there are instructions to manually configure this. The goal is that users don't touch individual files but rather use the installer to modify it.

I do wonder about https://hibernate.atlassian.net/browse/HHH-12927. It's been resolved for 4 years now so is it still needed?