### PR TITLE
Clean up .fixtures.yml style

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,13 +1,10 @@
+---
 fixtures:
   repositories:
-    stdlib:     'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-    extlib:     'https://github.com/voxpupuli/puppet-extlib'
-    concat:     'https://github.com/puppetlabs/puppetlabs-concat'
-    postgresql: 'https://github.com/puppetlabs/puppetlabs-postgresql.git'
-    selinux_core:
-      repo:           'https://github.com/puppetlabs/puppetlabs-selinux_core'
-      puppet_version: '>= 6.0.0'
+    concat: 'https://github.com/puppetlabs/puppetlabs-concat'
+    extlib: 'https://github.com/voxpupuli/puppet-extlib'
+    postgresql: 'https://github.com/puppetlabs/puppetlabs-postgresql'
+    selinux_core: 'https://github.com/puppetlabs/puppetlabs-selinux_core'
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
     systemd: 'https://github.com/voxpupuli/puppet-systemd'
-    yumrepo_core:
-      repo: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'
-      puppet_version: '>= 6.0.0'
+    yumrepo_core: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'


### PR DESCRIPTION
Drops the Puppet < 6 compatibility, which is no longer needed. It also applies a consistent formatting.