### PR TITLE
Update test suite to Java 17

### DIFF
--- a/examples/basic_candlepin.pp
+++ b/examples/basic_candlepin.pp
@@ -56,7 +56,7 @@ class { 'candlepin':
   keystore_password   => $keystore_password,
   truststore_file     => $truststore,
   truststore_password => $truststore_password,
-  java_package        => 'java-11-openjdk',
-  java_home           => '/usr/lib/jvm/jre-11',
+  java_package        => 'java-17-openjdk',
+  java_home           => '/usr/lib/jvm/jre-17',
   artemis_client_dn   => Deferred('pick', ['', 'CN=ActiveMQ Artemis Deferred, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ']),
 }

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -322,16 +322,16 @@ describe 'candlepin' do
       describe 'with java params' do
         let :params do
           {
-            java_package: 'java-11-openjdk',
-            java_home: '/usr/lib/jvm/jre-11'
+            java_package: 'java-17-openjdk',
+            java_home: '/usr/lib/jvm/jre-17'
           }
         end
 
-        it { is_expected.to contain_package('java-11-openjdk').that_comes_before('Service[tomcat]') }
+        it { is_expected.to contain_package('java-17-openjdk').that_comes_before('Service[tomcat]') }
 
         it do
           is_expected.to contain_file("/etc/tomcat/tomcat.conf").
-            with_content(/JAVA_HOME="\/usr\/lib\/jvm\/jre-11"/)
+            with_content(/JAVA_HOME="\/usr\/lib\/jvm\/jre-17"/)
         end
       end
 


### PR DESCRIPTION
The test suite uses nightly and that has updated Candlepin to a version that requires Java 17.