### PR TITLE
Ensure maven:3.8 is enabled on EL8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -170,6 +170,9 @@
 #   Disable FIPS within the Java environment for Tomcat explicitly.
 #   When set to false, no flag is added. Then on FIPS enabled systems, a Candlepin build that supports FIPS is required.
 #
+# @param maven_module_version
+#   Version of the maven module to use
+#
 # @example Set debug logging
 #   class { 'candlepin':
 #     loggers => {
@@ -233,6 +236,7 @@ class candlepin (
   String $user = 'tomcat',
   String $group = 'tomcat',
   Boolean $disable_fips = true,
+  String $maven_module_version = '3.8',
 ) inherits candlepin::params {
   contain candlepin::service
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,6 +12,14 @@ class candlepin::install {
   }
 
   if $enable_pki_core {
+    package { 'maven dnf module':
+      ensure      => $candlepin::maven_module_version,
+      name        => 'maven',
+      enable_only => true,
+      provider    => 'dnfmodule',
+      before      => Package['pki-core'],
+    }
+
     package { 'pki-core':
       ensure      => installed,
       enable_only => true,

--- a/spec/acceptance/dnf_module_spec.rb
+++ b/spec/acceptance/dnf_module_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper_acceptance'
+
+describe 'dnf module support' do
+ context 'when swapping to maven 3.8' do
+    before(:context) do
+      on default, 'dnf module reset maven -y'
+      on default, 'dnf module enable maven:3.5 -y'
+    end
+
+    include_examples 'the example', 'basic_candlepin.pp'
+
+    describe command('dnf module list --enabled --quiet') do
+      its(:stdout) { is_expected.to include('pki-core').and match(/^maven\s+3\.8/) }
+    end
+  end
+end

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -17,6 +17,12 @@ describe 'candlepin' do
         it { is_expected.to contain_package('candlepin').with_ensure('present') }
         it { is_expected.not_to contain_package('wget') }
         it { is_expected.to contain_package('pki-core').that_comes_before('Package[candlepin]') }
+        it do
+          is_expected.to contain_package('maven dnf module').
+            with_ensure('3.8').
+            with_name('maven').
+            that_comes_before('Package[pki-core]')
+        end
 
         # config
         it { is_expected.to contain_class('candlepin::config') }


### PR DESCRIPTION
The maven 3.5 and 3.6 modules are no longer supported on RHEL.