### PR TITLE
Fixes #36760 - Limit access to server.xml

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,9 +28,9 @@ class candlepin::config {
   file { '/etc/tomcat/server.xml':
     ensure  => file,
     content => template('candlepin/tomcat/server.xml.erb'),
-    mode    => '0644',
+    mode    => '0640',
     owner   => 'root',
-    group   => 'root',
+    group   => $candlepin::group,
   }
 
   file { '/etc/tomcat/tomcat.conf':


### PR DESCRIPTION
Prior to this the file was world readable, even though it contained passwords for the keystore. That keystore was limited to just the correct group, so it's not directly exploitable but these kind of things might be used in more complex attacks.

Fixes: 832bafa66c9f ("Initial commit of Candlepin module from the original katello-installer.")