### PR TITLE
Add baseurl parameter to repo class

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -12,15 +12,23 @@
 #
 # @param gpgkey
 #   The GPG key to use
+#
+# @param baseurl
+#   An optional base URL to be used for yumrepo, instead of the default
 class candlepin::repo (
-  String $version,
+  Variant[Undef, Enum['nightly'], Pattern['^\d+\.\d+$']] $version = undef,
   String $dist = "el${facts['os']['release']['major']}",
   Boolean $gpgcheck = false,
   Optional[String] $gpgkey = undef,
+  Optional[Stdlib::HTTPUrl] $baseurl = undef,
 ) {
+  unless $baseurl {
+    assert_type(NotUndef, $version)
+  }
+
   yumrepo { 'candlepin':
     descr    => 'Candlepin: an open source entitlement management system.',
-    baseurl  => "https://yum.theforeman.org/candlepin/${version}/${dist}/\$basearch/",
+    baseurl  => pick($baseurl, "https://yum.theforeman.org/candlepin/${version}/${dist}/\$basearch/"),
     gpgkey   => $gpgkey,
     gpgcheck => $gpgcheck,
     enabled  => true,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -20,7 +20,7 @@ class candlepin::repo (
 ) {
   yumrepo { 'candlepin':
     descr    => 'Candlepin: an open source entitlement management system.',
-    baseurl  => "https://yum.theforeman.org/katello/${version}/candlepin/${dist}/\$basearch/",
+    baseurl  => "https://yum.theforeman.org/candlepin/${version}/${dist}/\$basearch/",
     gpgkey   => $gpgkey,
     gpgcheck => $gpgcheck,
     enabled  => true,

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -4,23 +4,48 @@ describe 'candlepin::repo' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:params) do
-        { version: 'nightly' }
+
+      describe 'with nightly version' do
+        let(:params) do
+          { version: 'nightly' }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_yumrepo('candlepin')
+            .with_descr('Candlepin: an open source entitlement management system.')
+            .with_baseurl("https://yum.theforeman.org/candlepin/nightly/el#{facts[:os]['release']['major']}/\$basearch/")
+            .with_gpgkey(nil)
+            .with_gpgcheck(false)
+            .with_enabled(true)
+            .that_comes_before('Anchor[candlepin::repo]')
+        end
+
+        it { is_expected.to contain_anchor('candlepin::repo') }
       end
 
-      it { is_expected.to compile.with_all_deps }
+      describe 'with baseurl' do
+        let(:params) do
+          {
+            baseurl: "https://stagingyum.theforeman.org/candlepin/nightly/el#{facts[:os]['release']['major']}/\$basearch/"
+          }
+        end
 
-      it do
-        is_expected.to contain_yumrepo('candlepin')
-          .with_descr('Candlepin: an open source entitlement management system.')
-          .with_baseurl("https://yum.theforeman.org/candlepin/nightly/el#{facts[:os]['release']['major']}/\$basearch/")
-          .with_gpgkey(nil)
-          .with_gpgcheck(false)
-          .with_enabled(true)
-          .that_comes_before('Anchor[candlepin::repo]')
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_yumrepo('candlepin')
+            .with_descr('Candlepin: an open source entitlement management system.')
+            .with_baseurl("https://stagingyum.theforeman.org/candlepin/nightly/el#{facts[:os]['release']['major']}/\$basearch/")
+            .with_gpgkey(nil)
+            .with_gpgcheck(false)
+            .with_enabled(true)
+            .that_comes_before('Anchor[candlepin::repo]')
+        end
+
+        it { is_expected.to contain_anchor('candlepin::repo') }
       end
-
-      it { is_expected.to contain_anchor('candlepin::repo') }
     end
   end
 end

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -13,7 +13,7 @@ describe 'candlepin::repo' do
       it do
         is_expected.to contain_yumrepo('candlepin')
           .with_descr('Candlepin: an open source entitlement management system.')
-          .with_baseurl("https://yum.theforeman.org/katello/nightly/candlepin/el#{facts[:os]['release']['major']}/\$basearch/")
+          .with_baseurl("https://yum.theforeman.org/candlepin/nightly/el#{facts[:os]['release']['major']}/\$basearch/")
           .with_gpgkey(nil)
           .with_gpgcheck(false)
           .with_enabled(true)


### PR DESCRIPTION
This is to support setting this value to our staging repositories for testing of new builds of Candlepin.