### PR TITLE
Allow setting baseurl during acceptance tests

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -6,6 +6,7 @@ package { 'glibc-langpack-en':
 
 class { 'candlepin::repo':
   version => pick(fact('candlepin_version'), 'nightly'),
+  baseurl => fact('candlepin_baseurl'),
 }
 
 if $facts['os']['selinux']['enabled'] {


### PR DESCRIPTION
The intent is to allow test runs to set the baseurl to staging repository for example.