### PR TITLE
Use /etc/tomcat as configuration directory

### DIFF
--- a/manifests/artemis.pp
+++ b/manifests/artemis.pp
@@ -22,7 +22,7 @@ class candlepin::artemis {
     group   => $candlepin::group,
   }
 
-  file { "${candlepin::catalina_home}/conf/login.config":
+  file { "${candlepin::tomcat_conf}/login.config":
     ensure  => file,
     content => file('candlepin/tomcat/login.config'),
     mode    => '0640',
@@ -30,7 +30,7 @@ class candlepin::artemis {
     group   => $candlepin::group,
   }
 
-  file { "${candlepin::catalina_home}/conf/cert-users.properties":
+  file { "${candlepin::tomcat_conf}/cert-users.properties":
     ensure  => file,
     content => Deferred('inline_epp', ["katelloUser=<%= \$artemis_client_dn %>\n", { 'artemis_client_dn' => $candlepin::artemis_client_dn }]),
     mode    => '0640',
@@ -38,7 +38,7 @@ class candlepin::artemis {
     group   => $candlepin::group,
   }
 
-  file { "${candlepin::catalina_home}/conf/cert-roles.properties":
+  file { "${candlepin::tomcat_conf}/cert-roles.properties":
     ensure  => file,
     content => file('candlepin/tomcat/cert-roles.properties'),
     mode    => '0640',
@@ -46,7 +46,7 @@ class candlepin::artemis {
     group   => $candlepin::group,
   }
 
-  file { "${candlepin::catalina_home}/conf/conf.d/jaas.conf":
+  file { "${candlepin::tomcat_conf}/conf.d/jaas.conf":
     ensure  => file,
     content => file('candlepin/tomcat/jaas.conf'),
     mode    => '0640',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -55,7 +55,7 @@ class candlepin::config {
     'truststore_password' => $candlepin::_truststore_password,
   }
 
-  file { '/etc/tomcat/server.xml':
+  file { "${candlepin::tomcat_conf}/server.xml":
     ensure  => file,
     content => epp('candlepin/tomcat/server.xml.epp', $server_context),
     mode    => '0640',
@@ -63,7 +63,7 @@ class candlepin::config {
     group   => $candlepin::group,
   }
 
-  file { '/etc/tomcat/tomcat.conf':
+  file { "${candlepin::tomcat_conf}/tomcat.conf":
     ensure  => file,
     content => template('candlepin/tomcat/tomcat.conf.erb'),
     mode    => '0644',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,6 +124,9 @@
 #   In new-style instances, if CATALINA_BASE isn't specified, it will be
 #   constructed by joining TOMCATS_BASE and NAME.
 #
+# @param tomcat_conf
+#   Where your the tomcat configuration lives
+#
 # @param java_home
 #   Where your java installation lives
 #
@@ -218,6 +221,7 @@ class candlepin (
   Stdlib::Host $host = 'localhost',
   Stdlib::Absolutepath $candlepin_conf_file = '/etc/candlepin/candlepin.conf',
   Stdlib::Absolutepath $tomcat_base = '/var/lib/tomcats/',
+  Stdlib::Absolutepath $tomcat_conf = '/etc/tomcat',
   Stdlib::Absolutepath $java_home = '/usr/lib/jvm/jre',
   Stdlib::Absolutepath $catalina_home = '/usr/share/tomcat',
   Stdlib::Absolutepath $catalina_tmpdir = '/var/cache/tomcat/temp',

--- a/spec/acceptance/basic_candlepin_spec.rb
+++ b/spec/acceptance/basic_candlepin_spec.rb
@@ -29,7 +29,7 @@ describe 'candlepin works' do
     its(:stdout) { should match(/least strength: (A|strong)/) }
   end
 
-  describe file("/usr/share/tomcat/conf/cert-users.properties") do
+  describe file("/etc/tomcat/cert-users.properties") do
     it { should be_file }
     it { should be_mode 640 }
     it { should be_owned_by 'tomcat' }

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -52,11 +52,11 @@ describe 'candlepin' do
           ])
         end
 
-        it { is_expected.to contain_file('/usr/share/tomcat/conf/login.config') }
-        it { is_expected.to contain_file('/usr/share/tomcat/conf/cert-roles.properties') }
-        it { is_expected.to contain_file('/usr/share/tomcat/conf/conf.d/jaas.conf') }
+        it { is_expected.to contain_file('/etc/tomcat/login.config') }
+        it { is_expected.to contain_file('/etc/tomcat/cert-roles.properties') }
+        it { is_expected.to contain_file('/etc/tomcat/conf.d/jaas.conf') }
         it do
-          is_expected.to contain_file('/usr/share/tomcat/conf/cert-users.properties').
+          is_expected.to contain_file('/etc/tomcat/cert-users.properties').
             with_content("katelloUser=CN=ActiveMQ Artemis Client, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ\n")
         end
 

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -29,10 +29,10 @@ if $facts['os']['selinux']['enabled'] {
 
   # Workaround for https://github.com/theforeman/puppet-candlepin/issues/185#issuecomment-822284497
   $tomcat_conf_files = [
-    '/usr/share/tomcat/conf/login.config',
-    '/usr/share/tomcat/conf/cert-users.properties',
-    '/usr/share/tomcat/conf/cert-roles.properties',
-    '/usr/share/tomcat/conf/conf.d/jaas.conf'
+    '/etc/tomcat/login.config',
+    '/etc/tomcat/cert-users.properties',
+    '/etc/tomcat/cert-roles.properties',
+    '/etc/tomcat/conf.d/jaas.conf'
   ]
   file { $tomcat_conf_files:
     ensure   => file,


### PR DESCRIPTION
The /usr/share/tomcat/conf path is already a symlink to /etc/tomcat so this just makes it more explicit.