### PR TITLE
Add candlepin.consumer.facts.match_regex parameter to candlepin class

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,6 +30,7 @@ class candlepin::config {
     'oauth_key'                    => $candlepin::_oauth_key,
     'oauth_secret'                 => $candlepin::_oauth_secret,
     'db_manage_on_startup'         => $candlepin::db_manage_on_startup,
+    'facts_match_regex'            => $candlepin::facts_match_regex,
   }
 
   concat::fragment { 'General Config':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,10 @@
 # @param db_port
 #   Port the database listens on. Only needs to be provided if different from
 #   standard port of the :db_type.
+
+# @param facts_match_regex
+#   Optional regex to filter consumer facts; if provided, will be added to the
+#   Candlepin configuration file.
 #
 # @param db_ssl
 #   Boolean indicating if the connection to the database should be over an SSL
@@ -183,6 +187,7 @@ class candlepin (
   Enum['postgresql','mysql'] $db_type = 'postgresql',
   Stdlib::Host $db_host = 'localhost',
   Optional[Stdlib::Port] $db_port = undef,
+  Optional[String[1]] $facts_match_regex = undef,
   Boolean $db_ssl = false,
   Boolean $db_ssl_verify = true,
   Optional[Stdlib::Absolutepath] $db_ssl_ca = undef,

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -416,6 +416,17 @@ describe 'candlepin' do
         it { is_expected.to contain_exec('notification').that_notifies('Service[tomcat]') }
         it { is_expected.to contain_exec('dependency').that_requires('Service[tomcat]') }
       end
+
+      describe 'with facts match regex' do
+        let(:params) { { facts_match_regex: 'test_match_regex' } }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_concat__fragment('General Config').
+            with_content(sensitive(/^candlepin.consumer.facts.match_regex=test_match_regex$/))
+        end
+      end
     end
   end
 end

--- a/templates/candlepin.conf.epp
+++ b/templates/candlepin.conf.epp
@@ -6,6 +6,7 @@
   Stdlib::Absolutepath $ca_key,
   Optional[Sensitive[String]] $ca_key_password,
   Optional[String] $consumer_system_name_pattern,
+  Optional[String[1]] $facts_match_regex,
   Boolean $enable_basic_auth,
   Boolean $enable_trusted_auth,
   Boolean $env_filtering_enabled,
@@ -50,4 +51,8 @@ candlepin.async.jobs.ExpiredPoolsCleanupJob.schedule=<%= $expired_pools_schedule
 <% $loggers.each |$logger, $log_level| { %>
 log4j.logger.<%= $logger %>=<%= $log_level %>
 <% } %>
+<% } %>
+
+<% if $facts_match_regex { %>
+candlepin.consumer.facts.match_regex=<%= $facts_match_regex %>
 <% } %>


### PR DESCRIPTION
This change allows users to configure the `candlepin.consumer.facts.match_regex``
option via the puppet-candlepin module. This option filters facts to improve
performance by excluding unnecessary data.

- Add facts_match_regex parameter to candlepin class
- Update configuration files to include the new parameter
- Added test to validate the proper functioning of the new configuration option.

https://issues.redhat.com/browse/SAT-6777