### PR TITLE
Avoid dependency cycles with glibc-langpack-en

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -51,15 +51,14 @@ class candlepin::database::postgresql (
     }
 
     include postgresql::client, postgresql::server
-
-    stdlib::ensure_packages(['glibc-langpack-en'])
+    include candlepin::database::postgresql::encoding
 
     postgresql::server::db { $db_name:
       user     => $db_user,
       password => postgresql::postgresql_password($db_user, $db_password),
       encoding => 'utf8',
       locale   => 'en_US.utf8',
-      require  => Package['glibc-langpack-en'],
+      require  => Class['candlepin::database::postgresql::encoding'],
     }
   }
 

--- a/manifests/database/postgresql/encoding.pp
+++ b/manifests/database/postgresql/encoding.pp
@@ -1,0 +1,5 @@
+# @summary Class to ensure the packages for encoding are installed
+# @api private
+class candlepin::database::postgresql::encoding {
+  stdlib::ensure_packages(['glibc-langpack-en'])
+}


### PR DESCRIPTION
By calling `stdlib::ensure_packages()` in the class itself the resource gets tied to the class. If other packages also depend on the resource, you can get dependency cycles.

In particular, foreman also does this and that causes a dependency cycle.

By using a class that is included the resource "floats" in the catalog. We then only ensure the package is installed somewhere before we create the database.

Fixes: ca7714557135 ("Ensure glibc-langpack-en is always installed")