### PR TITLE
Drop EL8 support and update to Java 25

### DIFF
--- a/examples/basic_candlepin.pp
+++ b/examples/basic_candlepin.pp
@@ -56,6 +56,6 @@ class { 'candlepin':
   keystore_password   => $keystore_password,
   truststore_file     => $truststore,
   truststore_password => $truststore_password,
-  java_package        => 'java-17-openjdk',
-  java_home           => '/usr/lib/jvm/jre-17',
+  java_package        => 'java-25-openjdk',
+  java_home           => '/usr/lib/jvm/jre-25',
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,20 +4,9 @@
 class candlepin::install {
   assert_private()
 
-  $enable_pki_core = $facts['os']['release']['major'] == '8'
-
   if $candlepin::java_package {
     stdlib::ensure_packages([$candlepin::java_package])
     Package[$candlepin::java_package] -> Package['candlepin']
-  }
-
-  if $enable_pki_core {
-    package { 'pki-core':
-      ensure      => installed,
-      enable_only => true,
-      provider    => 'dnfmodule',
-      before      => Package['candlepin'],
-    }
   }
 
   package { ['candlepin']:
@@ -27,10 +16,6 @@ class candlepin::install {
   if $facts['os']['selinux']['enabled'] {
     package { ['candlepin-selinux']:
       ensure => $candlepin::version,
-    }
-
-    if $enable_pki_core {
-      Package['pki-core'] -> Package['candlepin-selinux']
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -39,21 +39,18 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "8",
         "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "8",
         "9"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
-        "8",
         "9"
       ]
     }

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -16,10 +16,6 @@ describe 'candlepin' do
         it { is_expected.to contain_class('candlepin::install') }
         it { is_expected.to contain_package('candlepin').with_ensure('present') }
 
-        if facts[:os]['release']['major'] == '8'
-          it { is_expected.to contain_package('pki-core').that_comes_before('Package[candlepin]') }
-        end
-
         # config
         it { is_expected.to contain_class('candlepin::config') }
         it { is_expected.to contain_user('tomcat').with_ensure('present').with_groups([]) }
@@ -212,9 +208,6 @@ describe 'candlepin' do
 
           it { is_expected.to compile.with_all_deps }
 
-          if facts[:os]['release']['major'] == '8'
-            it { is_expected.to contain_package('candlepin-selinux').that_requires('Package[pki-core]') }
-          end
         end
 
         describe 'off' do
@@ -306,16 +299,16 @@ describe 'candlepin' do
       describe 'with java params' do
         let :params do
           {
-            java_package: 'java-17-openjdk',
-            java_home: '/usr/lib/jvm/jre-17'
+            java_package: 'java-25-openjdk',
+            java_home: '/usr/lib/jvm/jre-25'
           }
         end
 
-        it { is_expected.to contain_package('java-17-openjdk').that_comes_before('Service[tomcat]') }
+        it { is_expected.to contain_package('java-25-openjdk').that_comes_before('Service[tomcat]') }
 
         it do
           is_expected.to contain_file("/etc/tomcat/tomcat.conf").
-            with_content(/JAVA_HOME="\/usr\/lib\/jvm\/jre-17"/)
+            with_content(/JAVA_HOME="\/usr\/lib\/jvm\/jre-25"/)
         end
       end
 

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,19 +1,6 @@
-$major = $facts['os']['release']['major']
-
 class { 'candlepin::repo':
   version => pick(fact('candlepin_version'), 'nightly'),
   baseurl => fact('candlepin_baseurl'),
-}
-
-if $facts['os']['selinux']['enabled'] {
-  # Workaround for https://github.com/theforeman/puppet-candlepin/issues/188
-  package { 'pki-core':
-    # enable_only is required as workaround for https://tickets.puppetlabs.com/browse/PUP-11024
-    enable_only => true,
-    ensure      => present,
-    provider    => 'dnfmodule',
-    before      => Package['candlepin-selinux'],
-  }
 }
 
 # Needed as a workaround for idempotency

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,6 @@
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
-ENV['BEAKER_setfile'] ||= 'centos8-64{hostname=centos8-64.example.com}'
+ENV['BEAKER_setfile'] ||= 'centos9-64{hostname=centos9-64.example.com}'
 
 configure_beaker(modules: :fixtures) do |host|
   if fact_on(host, 'os.family') == 'RedHat'


### PR DESCRIPTION
## Summary
Candlepin 4.8 requires Java 25 ([spec](https://github.com/candlepin/candlepin/blob/main/candlepin.spec.tmpl#L45): `Requires: java-25-headless >= 1:25.0.0`). Since `java-25-openjdk` is only available on EL9 and Satellite/Katello no longer supports running on EL8, this drops EL8 support from the module.

## Changes
- `examples/basic_candlepin.pp`: `java-17-openjdk` / `jre-17` → `java-25-openjdk` / `jre-25`
- `metadata.json`: removed EL8 from operatingsystem_support for RedHat, CentOS, AlmaLinux
- `manifests/install.pp`: removed `pki-core` EL8 dnfmodule workaround
- `spec/setup_acceptance_node.pp`: removed `pki-core` EL8 workaround
- `spec/spec_helper_acceptance.rb`: default beaker setfile `centos8` → `centos9`
- `spec/classes/candlepin_spec.rb`: updated Java test values, removed EL8 `pki-core` assertions

Follows the pattern from #231 (Java 11 → 17).

## Test plan
- [x] Verified locally: puppet apply with Candlepin 4.8.1 + Java 25 returns HTTP 200 on `/candlepin/status`
- [ ] GHA CI acceptance tests pass on EL9