### PR TITLE
Set database owner to fix PG 15+ schema permissions

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -58,6 +58,7 @@ class candlepin::database::postgresql (
       password => postgresql::postgresql_password($db_user, $db_password),
       encoding => 'utf8',
       locale   => 'en_US.utf8',
+      owner    => $db_user,
       require  => Class['candlepin::database::postgresql::encoding'],
     }
 


### PR DESCRIPTION
## Summary
- Add `owner` parameter to `postgresql::server::db` resource so the candlepin database is owned by the `candlepin` user instead of `postgres`
- PostgreSQL 15+ revokes `CREATE` on the `public` schema by default — only the database owner retains it
- Without this fix, candlepin cannot create tables in the `public` schema when running against PG 15+

## Root Cause
The `public` schema in PG 15+ is owned by `pg_database_owner`, a special role that maps to the database owner. When the database is owned by `postgres` (the default when `owner` is not set), the `candlepin` user has no `CREATE` privilege on the `public` schema.

Note: `puppet-foreman` already sets `owner` correctly — this aligns `puppet-candlepin` with that pattern.

## Test plan
- [x] Verified fix on a RHEL 9.8 instance with PG 16 — installer completed successfully after patching this file
- [ ] Existing rspec tests pass (they check resource existence, not parameters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)