### PR TITLE
Fix Tomcat SSL connector config for Tomcat 10.1+ (EL10)

### DIFF
--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -106,7 +106,7 @@ describe 'candlepin' do
         end
         it do
           is_expected.to contain_file('/etc/tomcat/server.xml').
-            with_content(sensitive(/^ *keystorePass="MY_KEYSTORE_PASSWORD"$/))
+            with_content(sensitive(/^ *certificateKeystorePassword="MY_KEYSTORE_PASSWORD"$/))
         end
       end
 
@@ -291,8 +291,7 @@ describe 'candlepin' do
         it { is_expected.to compile.with_all_deps }
         it do
           is_expected.to contain_file("/etc/tomcat/server.xml").
-            with_content(/sslProtocol="TLSv1.2,TLSv1.3"/).
-            with_content(/sslEnabledProtocols="TLSv1.2,TLSv1.3"/)
+            with_content(/protocols="TLSv1.2,TLSv1.3"/)
         end
       end
 

--- a/templates/tomcat/server.xml.epp
+++ b/templates/tomcat/server.xml.epp
@@ -88,16 +88,18 @@
                address="<%= $host %>"
                protocol="HTTP/1.1"
                SSLEnabled="true"
-               maxThreads="150" scheme="https" secure="true"
-               clientAuth="want"
-               sslProtocol="<%= $tls_versions.map |$version| { "TLSv${version}" }.join(",") %>"
-               sslEnabledProtocols="<%= $tls_versions.map |$version| { "TLSv${version}" }.join(",") %>"
-               keystoreFile="<%= $keystore_file %>"
-               keystorePass="<%= $keystore_password %>"
-               keystoreType="<%= $keystore_type %>"
-               truststoreFile="<%= $truststore_file %>"
-               truststorePass="<%= $truststore_password %>"
-               ciphers="<%= $ciphers.join(",\n                    ") %>" />
+               maxThreads="150" scheme="https" secure="true">
+      <SSLHostConfig certificateVerification="optional"
+                     protocols="<%= $tls_versions.map |$version| { "TLSv${version}" }.join(",") %>"
+                     truststoreFile="<%= $truststore_file %>"
+                     truststorePassword="<%= $truststore_password %>"
+                     truststoreType="<%= $keystore_type %>"
+                     ciphers="<%= $ciphers.join(",\n                    ") %>">
+        <Certificate certificateKeystoreFile="<%= $keystore_file %>"
+                     certificateKeystorePassword="<%= $keystore_password %>"
+                     certificateKeystoreType="<%= $keystore_type %>" />
+      </SSLHostConfig>
+    </Connector>
 
     <!-- An Engine represents the entry point (within Catalina) that processes
          every request.  The Engine implementation for Tomcat stand alone


### PR DESCRIPTION
## Summary

Tomcat 10.1 (shipped on EL10 — CentOS Stream 10 / AlmaLinux 10) dropped support for configuring SSL directly as attributes on `<Connector>` (`keystoreFile`, `keystorePass`, `keystoreType`, `truststoreFile`, `truststorePass`, `sslProtocol`, `sslEnabledProtocols`, `ciphers`, `clientAuth`). Those must now live in a nested `<SSLHostConfig>`/`<Certificate>` element.

Without this change, every one of those attributes silently fails to set (`SetPropertiesRule` digester warnings), no `SSLHostConfig` gets created, and the connector fails to initialize:

```
IllegalArgumentException: No SSLHostConfig element was found with the hostName [_default_]
to match the defaultSSLHostConfigName for the connector [https-jsse-nio-127.0.0.1-8443]
```

...so candlepin never listens on its HTTPS port. This broke the `candlepin-5.0-rpm-pipeline` Jenkins job for both `almalinux10` and `centos10-stream` (see `spec/acceptance/basic_candlepin_spec.rb` failures: port 8443 not listening, `curl` returning `000`, and the nmap TLS checks failing since nothing was listening).

## Fix

- `templates/tomcat/server.xml.epp`: move the SSL config into a nested `<SSLHostConfig>` (with `<Certificate>` for the keystore), translating `clientAuth="want"` to the modern `certificateVerification="optional"` equivalent, and fixing `truststorePass` → `truststorePassword` (the old name is not a valid `SSLHostConfig` attribute — using it left the truststore password unset, which silently produced zero usable CA certs and failed with `the trustAnchors parameter must be non-empty` even after the `SSLHostConfig` was correctly recognized).
- `spec/classes/candlepin_spec.rb`: updated the two assertions that checked for the old flat `keystorePass`/`sslProtocol` attributes to match the new nested structure.

`<SSLHostConfig>` has been supported since Tomcat 8.5, so this isn't an EL10-only syntax — it works on EL9's Tomcat 9.x too.

## Test plan

Reproduced and fixed locally using forklift's real acceptance pipeline (`pipelines/candlepin.yml`), pointed at this branch:

- [x] `pipeline_version=5.0 pipeline_os=centos10-stream` (Tomcat 10.1, the originally failing case) — full `bundle exec rake beaker` run passes, `failed=0`.
- [x] `pipeline_version=4.8 pipeline_os=centos9-stream` (Tomcat 9.x, what's actually used in the current 4.8 pipeline) — confirmed no regression, `failed=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)